### PR TITLE
Stop the motors on basic_test_all.py exit

### DIFF
--- a/Software/Python/basic_test_all.py
+++ b/Software/Python/basic_test_all.py
@@ -1,6 +1,9 @@
 from gopigo import *
 import sys
 
+import atexit
+atexit.register(stop)
+
 while True:
 	print "\nCmd:",
 	a=raw_input()


### PR DESCRIPTION
For safety.

There is no use case for an uncontrolled robot, at least in the simple demo. If you want to put this in the main Python library instead, by all means. 
