### PR TITLE
Less threatening warning message

### DIFF
--- a/Software/Scratch/GoPiGoScratch.py
+++ b/Software/Scratch/GoPiGoScratch.py
@@ -471,8 +471,7 @@ while True:
 					
 		else: 
 			if en_debug:
-				print "m",msg
-				print "Wrong Command"
+				print "Ignoring Command: ", msg
 				
 		
     except KeyboardInterrupt:

--- a/Software/Scratch/GoPiGoScratch.py
+++ b/Software/Scratch/GoPiGoScratch.py
@@ -471,7 +471,7 @@ while True:
 					
 		else: 
 			if en_debug:
-				print "Ignoring Command: ", msg[1]
+				print "Ignoring Command: ", msg
 				
 		
     except KeyboardInterrupt:

--- a/Software/Scratch/GoPiGoScratch.py
+++ b/Software/Scratch/GoPiGoScratch.py
@@ -471,7 +471,7 @@ while True:
 					
 		else: 
 			if en_debug:
-				print "Ignoring Command: ", msg
+				print "Ignoring Command: ", msg[1]
 				
 		
     except KeyboardInterrupt:


### PR DESCRIPTION
If the user creates other broadcast messages, GoPiGoScratch.py spits out "Wrong command". That's not entirely true. they're perfectly good command, just not meant for GoPiGoScratch. Changed the text to say "Ignoring command" followed by the command in question.