### PR TITLE
Bump i2c-bus

### DIFF
--- a/Software/NodeJS/libs/.gitignore
+++ b/Software/NodeJS/libs/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/Software/NodeJS/libs/package.json
+++ b/Software/NodeJS/libs/package.json
@@ -1,27 +1,32 @@
 {
-    "name": "node-gopigo",
-    "version": "2.0.4",
-    "description": "GoPiGo library for Node.js",
-    "keywords": ["gopigo", "robot", "gpio", "i2c"],
-    "dependencies": {
-        "async": "0.9.0",
-        "buffertools": "2.1.*",
-        "i2c-bus": "0.11.*",
-        "npmlog": "1.2.*",
-        "sleep": "3.0.*"
-    },
-    "main": "index.js",
-    "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/marcellobarile/GoPiGo.git"
-    },
-    "author": "Marcello Barile <marcello.barile@gmail.com> (http://www.barile.eu)",
-    "license": "MIT",
-    "bugs": {
-        "url": "https://github.com/marcellobarile/GoPiGo/issues"
-    },
-    "homepage": "https://github.com/marcellobarile/GoPiGo"
+  "name": "node-gopigo",
+  "version": "2.0.4",
+  "description": "GoPiGo library for Node.js",
+  "keywords": [
+    "gopigo",
+    "robot",
+    "gpio",
+    "i2c"
+  ],
+  "dependencies": {
+    "async": "0.9.0",
+    "buffertools": "2.1.*",
+    "i2c-bus": "^1.1.0",
+    "npmlog": "1.2.*",
+    "sleep": "3.0.*"
+  },
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/marcellobarile/GoPiGo.git"
+  },
+  "author": "Marcello Barile <marcello.barile@gmail.com> (http://www.barile.eu)",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/marcellobarile/GoPiGo/issues"
+  },
+  "homepage": "https://github.com/marcellobarile/GoPiGo"
 }


### PR DESCRIPTION
I found a problem when install `node-gopigo` with `nodejs v6`, because of the version of `i2c-bus`:

```
> i2c-bus@0.11.3 install /home/pi/gamepadgo-client/node_modules/i2c-bus
> node-gyp rebuild

make: Entering directory '/home/pi/gamepadgo-client/node_modules/i2c-bus/build'
  CXX(target) Release/obj.target/i2c/src/i2c.o
In file included from ../src/i2c.cc:2:0:
../../nan/nan.h:590:20: error: variable or field ‘AddGCEpilogueCallback’ declared void
       v8::Isolate::GCEpilogueCallback callback
                    ^
../../nan/nan.h:590:7: error: ‘GCEpilogueCallback’ is not a member of ‘v8::Isolate’
       v8::Isolate::GCEpilogueCallback callback
       ^
../../nan/nan.h:591:18: error: expected primary-expression before ‘gc_type_filter’
     , v8::GCType gc_type_filter = v8::kGCTypeAll) {
                  ^
../../nan/nan.h:596:20: error: variable or field ‘RemoveGCEpilogueCallback’ declared void
       v8::Isolate::GCEpilogueCallback callback) {
                    ^
../../nan/nan.h:596:7: error: ‘GCEpilogueCallback’ is not a member of ‘v8::Isolate’
       v8::Isolate::GCEpilogueCallback callback) {
       ^
../../nan/nan.h:601:20: error: variable or field ‘AddGCPrologueCallback’ declared void
       v8::Isolate::GCPrologueCallback callback
                    ^
../../nan/nan.h:601:7: error: ‘GCPrologueCallback’ is not a member of ‘v8::Isolate’
       v8::Isolate::GCPrologueCallback callback
       ^
../../nan/nan.h:602:18: error: expected primary-expression before ‘gc_type_filter’
     , v8::GCType gc_type_filter = v8::kGCTypeAll) {
                  ^
../../nan/nan.h:607:20: error: variable or field ‘RemoveGCPrologueCallback’ declared void
       v8::Isolate::GCPrologueCallback callback) {
                    ^
../../nan/nan.h:607:7: error: ‘GCPrologueCallback’ is not a member of ‘v8::Isolate’
       v8::Isolate::GCPrologueCallback callback) {
       ^
i2c.target.mk:88: recipe for target 'Release/obj.target/i2c/src/i2c.o' failed
make: *** [Release/obj.target/i2c/src/i2c.o] Error 1
make: Leaving directory '/home/pi/gamepadgo-client/node_modules/i2c-bus/build'
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:276:23)
gyp ERR! stack     at emitTwo (events.js:106:13)
gyp ERR! stack     at ChildProcess.emit (events.js:191:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:204:12)
gyp ERR! System Linux 4.4.9-v7+
gyp ERR! command "/usr/local/bin/node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /home/pi/gamepadgo-client/node_modules/i2c-bus
gyp ERR! node -v v6.2.0
gyp ERR! node-gyp -v v3.3.1
gyp ERR! not ok
```

Please merge this PR to solve the problem.