### PR TITLE
Paths cleanup

### DIFF
--- a/Software/Python/line_follower/line_sensor.py
+++ b/Software/Python/line_follower/line_sensor.py
@@ -67,9 +67,10 @@ black_line=[0]*5
 # range_col=list(map(operator.sub, black, white))
 range_col=[0]*5
 
-file_b='black_line.txt'
-file_w='white_line.txt'
-file_r='range_line.txt'
+path="/home/pi/"
+file_b=path+'black_line.txt'
+file_w=path+'white_line.txt'
+file_r=path+'range_line.txt'
 # Function declarations of the various functions used for encoding and sending
 # data from RPi to Arduino
 

--- a/Software/Python/line_follower/line_sensor.py
+++ b/Software/Python/line_follower/line_sensor.py
@@ -67,10 +67,10 @@ black_line=[0]*5
 # range_col=list(map(operator.sub, black, white))
 range_col=[0]*5
 
-path="/home/pi/"
-file_b=path+'black_line.txt'
-file_w=path+'white_line.txt'
-file_r=path+'range_line.txt'
+dir_path="/home/pi/"
+file_b=dir_path+'black_line.txt'
+file_w=dir_path+'white_line.txt'
+file_r=dir_path+'range_line.txt'
 # Function declarations of the various functions used for encoding and sending
 # data from RPi to Arduino
 

--- a/Software/Python/line_follower/line_sensor_gui.py
+++ b/Software/Python/line_follower/line_sensor_gui.py
@@ -1,100 +1,108 @@
 #!/usr/bin/python
 
 try:
-    import wx
+	import wx
 except ImportError:
-    raise ImportError,"The wxPython module is required to run this program"
+	raise ImportError,"The wxPython module is required to run this program"
 
-try:
-    import sys
-    sys.path.insert(0, '/home/pi/Desktop/GoPiGo/Software/Python/line_follower')
+try:  #first look for libraries in the same folder
+	import sys
+	#sys.path.insert(0, '/home/pi/Desktop/GoPiGo/Software/Python/line_follower')
 
-    import line_sensor
-    import scratch_line
+	import line_sensor
+	import scratch_line
 except ImportError:
-    raise ImportError,"Line sensor libraries not found"
-  
+	try:  # look in the standard Raspbian for Robots folder. 
+		sys.path.insert(0, '/home/pi/Desktop/GoPiGo/Software/Python/line_follower')
+
+		import line_sensor
+		import scratch_line
+
+	except ImportError:
+		raise ImportError,"Line sensor libraries not found"
+		sys.exit(0)
+
 y=175 
 class line_sensor_app(wx.Frame):
-    def __init__(self,parent,id,title):
-        wx.Frame.__init__(self,parent,id,title,size=(475,400))
-        self.parent = parent
-        self.initialize()
-        # Exit
-        exit_button = wx.Button(self, label="Exit", pos=(25,350))
-        exit_button.Bind(wx.EVT_BUTTON, self.onClose)
-        
-        robot = "/home/pi/Desktop/GoBox/Troubleshooting_GUI/dex.png"
-        png = wx.Image(robot, wx.BITMAP_TYPE_ANY).ConvertToBitmap()
-        wx.StaticBitmap(self, -1, png, (395, 275), (png.GetWidth()-320, png.GetHeight()-10))
-        self.Bind(wx.EVT_ERASE_BACKGROUND, self.OnEraseBackground)		# Sets background picture
-    
-    #----------------------------------------------------------------------
-    def OnEraseBackground(self, evt):
-        """
-        Add a picture to the background
-        """
-        # yanked from ColourDB.py
-        dc = evt.GetDC()
- 
-        if not dc:
-            dc = wx.ClientDC(self)
-            rect = self.GetUpdateRegion().GetBox()
-            dc.SetClippingRect(rect)
-        dc.Clear()	
-        bmp = wx.Bitmap("/home/pi/Desktop/GoBox/Troubleshooting_GUI/dex.png")	# Draw the photograph.
-        dc.DrawBitmap(bmp, 0, 400)						# Absolute position of where to put the picture
-
-
-    def initialize(self):
-        sizer = wx.GridBagSizer()
-
-        # Set up buttons
-        black_line_set_button = wx.Button(self,-1,label="Set Black Line Values", pos=(25,y))
-        sizer.Add(black_line_set_button, (0,1))
-        self.Bind(wx.EVT_BUTTON, self.black_line_set_OnButtonClick, black_line_set_button)
-
-        white_line_set_button = wx.Button(self,-1,label="Set White Line Values", pos=(175,y))
-        sizer.Add(white_line_set_button, (0,1))
-        self.Bind(wx.EVT_BUTTON, self.white_line_set_button_OnButtonClick, white_line_set_button)
-
-        line_position_set_button = wx.Button(self,-1,label="Read Line Position", pos=(325,y))
-        sizer.Add(line_position_set_button, (0,1))
-        self.Bind(wx.EVT_BUTTON, self.line_position_set_button_OnButtonClick, line_position_set_button)
-        
-        # Set up labels
-        self.label = wx.StaticText(self,-1,label=u'  ',pos=(25,y+150))
-        
-        self.label_top = wx.StaticText(self,-1,label=u'Instructions:\n 1.\tPlace the line sensor so that all of the black sensors are over \n\tyour black line.  Then press the button "Black Line Sensor Set".\n\n 2.\tNext, place the line sensor so that all of the black sensors are \n\tNOT over your black line and on the white background surface.\n\tThen press "White Line Sensor Set".\n\n 3.\tFinally, test the sensor by pressing "Read Line Position"',pos=(25,0))
-
-        sizer.Add( self.label, (1,0),(1,2), wx.EXPAND )
-        sizer.Add( self.label_top, (1,0),(1,2), wx.EXPAND )
-
-        self.Show(True)
-
-    def black_line_set_OnButtonClick(self,event):
-        for i in range(2):
-            line_sensor.get_sensorval()
-        line_sensor.set_black_line()
-        line_val=line_sensor.get_black_line()
-        self.label.SetLabel("Black Line : "+str(line_val))
-        
+	def __init__(self,parent,id,title):
+		wx.Frame.__init__(self,parent,id,title,size=(475,400))
+		self.parent = parent
+		self.initialize()
+		# Exit
+		exit_button = wx.Button(self, label="Exit", pos=(25,350))
+		exit_button.Bind(wx.EVT_BUTTON, self.onClose)
+		
+		robot = "/home/pi/Desktop/GoBox/Troubleshooting_GUI/dex.png"
+		png = wx.Image(robot, wx.BITMAP_TYPE_ANY).ConvertToBitmap()
+		wx.StaticBitmap(self, -1, png, (395, 275), (png.GetWidth()-320, png.GetHeight()-10))
+		self.Bind(wx.EVT_ERASE_BACKGROUND, self.OnEraseBackground)		# Sets background picture
 	
-    def white_line_set_button_OnButtonClick(self,event):
-        for i in range(2):
-            line_sensor.get_sensorval()
-        line_sensor.set_white_line()
-        line_val=line_sensor.get_white_line()
-        self.label.SetLabel("White Line : "+str(line_val))
-        
-    def line_position_set_button_OnButtonClick(self,event):
-        line_val=scratch_line.absolute_line_pos()
-        self.label.SetLabel("Line Position : "+str(line_val))
+	#----------------------------------------------------------------------
+	def OnEraseBackground(self, evt):
+		"""
+		Add a picture to the background
+		"""
+		# yanked from ColourDB.py
+		dc = evt.GetDC()
+ 
+		if not dc:
+			dc = wx.ClientDC(self)
+			rect = self.GetUpdateRegion().GetBox()
+			dc.SetClippingRect(rect)
+		dc.Clear()	
+		bmp = wx.Bitmap("/home/pi/Desktop/GoBox/Troubleshooting_GUI/dex.png")	# Draw the photograph.
+		dc.DrawBitmap(bmp, 0, 400)						# Absolute position of where to put the picture
 
-    def onClose(self, event):	# Close the entire program.
-        self.Close()
+
+	def initialize(self):
+		sizer = wx.GridBagSizer()
+
+		# Set up buttons
+		black_line_set_button = wx.Button(self,-1,label="Set Black Line Values", pos=(25,y))
+		sizer.Add(black_line_set_button, (0,1))
+		self.Bind(wx.EVT_BUTTON, self.black_line_set_OnButtonClick, black_line_set_button)
+
+		white_line_set_button = wx.Button(self,-1,label="Set White Line Values", pos=(175,y))
+		sizer.Add(white_line_set_button, (0,1))
+		self.Bind(wx.EVT_BUTTON, self.white_line_set_button_OnButtonClick, white_line_set_button)
+
+		line_position_set_button = wx.Button(self,-1,label="Read Line Position", pos=(325,y))
+		sizer.Add(line_position_set_button, (0,1))
+		self.Bind(wx.EVT_BUTTON, self.line_position_set_button_OnButtonClick, line_position_set_button)
+		
+		# Set up labels
+		self.label = wx.StaticText(self,-1,label=u'  ',pos=(25,y+150))
+		
+		self.label_top = wx.StaticText(self,-1,label=u'Instructions:\n 1.\tPlace the line sensor so that all of the black sensors are over \n\tyour black line.  Then press the button "Black Line Sensor Set".\n\n 2.\tNext, place the line sensor so that all of the black sensors are \n\tNOT over your black line and on the white background surface.\n\tThen press "White Line Sensor Set".\n\n 3.\tFinally, test the sensor by pressing "Read Line Position"',pos=(25,0))
+
+		sizer.Add( self.label, (1,0),(1,2), wx.EXPAND )
+		sizer.Add( self.label_top, (1,0),(1,2), wx.EXPAND )
+
+		self.Show(True)
+
+	def black_line_set_OnButtonClick(self,event):
+		for i in range(2):
+			line_sensor.get_sensorval()
+		line_sensor.set_black_line()
+		line_val=line_sensor.get_black_line()
+		self.label.SetLabel("Black Line : "+str(line_val))
+		
+	
+	def white_line_set_button_OnButtonClick(self,event):
+		for i in range(2):
+			line_sensor.get_sensorval()
+		line_sensor.set_white_line()
+		line_val=line_sensor.get_white_line()
+		self.label.SetLabel("White Line : "+str(line_val))
+		
+	def line_position_set_button_OnButtonClick(self,event):
+		line_val=scratch_line.absolute_line_pos()
+		self.label.SetLabel("Line Position : "+str(line_val))
+
+	def onClose(self, event):	# Close the entire program.
+		self.Close()
 
 if __name__ == "__main__":
-    app = wx.App()
-    frame = line_sensor_app(None,-1,'Line Follower Calibration')
-    app.MainLoop()
+	app = wx.App()
+	frame = line_sensor_app(None,-1,'Line Follower Calibration')
+	app.MainLoop()

--- a/Software/Python/line_follower/scratch_line.py
+++ b/Software/Python/line_follower/scratch_line.py
@@ -8,9 +8,10 @@ poll_time=0.01
 
 # Calibration Files.  These are fixed positions because we assume
 # The user is using Raspbian for Robots.
-file_b="/home/pi/Desktop/GoPiGo/Software/Python/line_follower/black_line.txt"
-file_w="/home/pi/Desktop/GoPiGo/Software/Python/line_follower/white_line.txt"
-file_r="/home/pi/Desktop/GoPiGo/Software/Python/line_follower/range_line.txt"
+dir_path="/home/pi/"
+file_b=dir_path+"black_line.txt"
+file_w=dir_path+"white_line.txt"
+file_r=dir_path+"range_line.txt"
 
 last_val=[0]*5
 curr=[0]*5


### PR DESCRIPTION
line_sensor.py -> no path was set for the readout files. Using the GUI saved those in home directory.
scratch_line.py -> paths were hardcoded to read from Desktop/GoPiGo/Software/Python/line_follower. Now reading from home directory

line_sensor_gui.py -> libraries were hardcoded to read from Desktop/etc.. which stopped people from using the line follower if they don't have Raspbian for Robots. A more intelligent import is now implemented. 