### PR TITLE
IR Receiver failing msg

### DIFF
--- a/Software/Scratch/GoPiGoScratch.py
+++ b/Software/Scratch/GoPiGoScratch.py
@@ -360,14 +360,23 @@ while True:
 			print "IR!"
 			if en_ir_sensor==0:
 				import lirc
-				sockid = lirc.init("keyes", blocking = False)
-				en_ir_sensor=1
+				try:
+					sockid = lirc.init("keyes", blocking = False)
+					en_ir_sensor=1
+				except:
+					en_ir_sensor=0
+					print("*******************************")
+					print("ERROR: IR Receiver not enabled!")
+					print("Please run Advanced Communications Option and enable it")
+					print("A REBOOT will be necessary")
+					print("*******************************")
 			try:
-				a= lirc.nextcode()  # press a button on the remote 
-				if len(a) !=0:
-					print a[0]
-				else:
-					a.append(0)		#return 0 if no keypress found 
+				if en_ir_sensor==1:
+					a= lirc.nextcode()  # press a button on the remote 
+					if len(a) !=0:
+						print a[0]
+					else:
+						a.append(0)		#return 0 if no keypress found 
 			except:
 				if en_debug:
 					e = sys.exc_info()[1]


### PR DESCRIPTION
Added some error messages when IR receiver is not enabled but user tries to access it. The messages are showing up in the terminal window so I'm not entirely happy with that. But it's better than crashing and will help customer support. If only we had a way of sending error messages back to Scratch...