### PR TITLE
no more stray index.html files left behind

### DIFF
--- a/Setup/install.sh
+++ b/Setup/install.sh
@@ -57,10 +57,9 @@ echo "Installing GoPiGo software in $SCRIPTDIR"
 echo " "
 echo "Check for internet connectivity..."
 echo "=================================="
-wget -q --tries=2 --timeout=20 http://raspberrypi.org 
+wget -q --tries=2 --timeout=20 --output-document=/dev/null http://raspberrypi.org 
 if [ $? -eq 0 ];then
 	echo "Connected"
-	sudo rm index.html
 else
 	echo "Unable to Connect, try again !!!"
 	exit 0

--- a/Software/Python/Examples/Browser_Streaming_Robot/browser_stream_setup.sh
+++ b/Software/Python/Examples/Browser_Streaming_Robot/browser_stream_setup.sh
@@ -22,7 +22,7 @@ read
 echo " "
 echo "Check for internet connectivity..."
 echo "=================================="
-wget -q --tries=2 --timeout=20 --output-document=/dev/null http://google.com
+wget -q --tries=2 --timeout=20 --output-document=/dev/null http://raspberrypi.org
 if [ $? -eq 0 ];then
 	echo "Connected"
 else

--- a/Software/Python/Examples/Browser_Streaming_Robot/browser_stream_setup.sh
+++ b/Software/Python/Examples/Browser_Streaming_Robot/browser_stream_setup.sh
@@ -22,7 +22,7 @@ read
 echo " "
 echo "Check for internet connectivity..."
 echo "=================================="
-wget -q --tries=2 --timeout=20 http://google.com
+wget -q --tries=2 --timeout=20 --output-document=/dev/null http://google.com
 if [ $? -eq 0 ];then
 	echo "Connected"
 else

--- a/Software/Python/ir_remote_control/script/ir_install_manually.sh
+++ b/Software/Python/ir_remote_control/script/ir_install_manually.sh
@@ -18,7 +18,7 @@ printf "WELCOME TO IR RECEIVER SETUP FOR THE GOPIGO.\nPlease ensure internet con
 echo " "
 echo "Check for internet connectivity..."
 echo "=================================="
-wget -q --tries=2 --timeout=20 http://google.com
+wget -q --tries=2 --timeout=20 --output-document=/dev/null http://raspberrypi.org
 if [ $? -eq 0 ];then
 	echo "Connected"
 else


### PR DESCRIPTION
When doing a wget to test internet connectivity in a script file, redirect to /dev/null to avoid leaving behind orphaned index.html files. 
Also avoid using google.com as a test since it is blocked in some countries.