### PR TITLE
DHT Sensor: Couldn't program the DHT if it wasn't plugged in

### DIFF
--- a/Software/Scratch/GoPiGoScratch.py
+++ b/Software/Scratch/GoPiGoScratch.py
@@ -476,9 +476,8 @@ while True:
 					print("DHT sensor: bad reading" )
 				elif dht_temp == -3.0 or dht_humidity == -3.0:
 					print("DHT sensor: not sudo" )
-				else:
-					s.sensorupdate({'temperature':dht_temp})
-					s.sensorupdate({'humidity':dht_humidity})
+				s.sensorupdate({'temperature':dht_temp})
+				s.sensorupdate({'humidity':dht_humidity})
 
 				
 		else: 


### PR DESCRIPTION
send sensorvalue even on error to allow users to program even if the DHT is not currently plugged in.
Now if there's an error with the DHT it's actually catchable from within Scratch