### PR TITLE
Added "from __future__"

### DIFF
--- a/Software/Python/line_follower/line_follow.py
+++ b/Software/Python/line_follower/line_follow.py
@@ -7,8 +7,8 @@
 #
 # http://www.dexterindustries.com/
 
-
-
+from __future__ import print_function
+from __future__ import division
 from builtins import input
 # the above lines are meant for Python3 compatibility.
 # they force the use of Python3 functionality for print(),

--- a/Software/Python/line_follower/line_follow1.py
+++ b/Software/Python/line_follower/line_follow1.py
@@ -20,6 +20,14 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/gpl-3.0.txt>.
 '''
+from __future__ import print_function
+from __future__ import division
+from builtins import input
+
+# the above lines are meant for Python3 compatibility.
+# they force the use of Python3 functionality for print(), 
+# the integer division and input()
+# mind your parentheses!
 import line_sensor
 import time
 import gopigo

--- a/Software/Python/line_follower/line_position.py
+++ b/Software/Python/line_follower/line_position.py
@@ -27,6 +27,14 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/gpl-3.0.txt>.
 '''
 
+from __future__ import print_function
+from __future__ import division
+from builtins import input
+# the above lines are meant for Python3 compatibility.
+# they force the use of Python3 functionality for print(), 
+# the integer division and input()
+# mind your parentheses!
+
 import line_sensor
 import time
 


### PR DESCRIPTION
By adding "from __future__ import print_function"  we are making certain that all future development will be Python2/3 compatible. At least for the print function and the division.
FYI:   one must also do `sudo pip install -U future` on their SD card for the code to work. This line is already added to DI Update. 