### PR TITLE
wifi test for cinch added

### DIFF
--- a/Troubleshooting/all_tests.sh
+++ b/Troubleshooting/all_tests.sh
@@ -21,4 +21,16 @@ sudo ./firmware_version_test.sh 2>&1| tee -a log.txt
 sudo ./motor_enc_led_test.sh 2>&1| tee -a log.txt  
 
 cp log.txt /home/pi/Desktop/log.txt
+
+if [ ! -f /home/pi/cinch ]; then
+    echo "No Cinch Found."
+else
+    feedback "Found cinch, running wifi debug install."
+    pushd /home/pi/di_update/Raspbian_For_Robots/Troubleshooting_GUI
+	sudo bash wifi_debug_info.sh
+	cat wireless-info.txt >> /home/pi/Desktop/log.txt
+	sudo cp /home/pi/Desktop/log.txt /boot
+	popd
+fi
+
 echo "Log has been saved to Desktop. Please copy it and send it by email or upload it on the forums"


### PR DESCRIPTION
- If cinch is detect, run the wifi test script and append the log to the log.txt and also store a copy in /boot for easy retrieval. Sample wifi log here: http://pastebin.com/aEXptP7y 