### PR TITLE
Changes to support firmware update from di update

### DIFF
--- a/Firmware/gopigo_firmware_update.sh
+++ b/Firmware/gopigo_firmware_update.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 REPO_PATH=$(readlink -f $(dirname $0) | grep -E -o "^(.*?\\GoPiGo)")
 update_gopigo_firmware(){ 
+	if [[ "$1" == "Dexter" ]]
+	then
+	    REPO_PATH=/home/pi/Dexter/GoPiGo
+	fi
+	echo "$REPO_PATH"
 	sudo avrdude -c gpio -p m328p -U lfuse:w:0x7F:m
 	sudo avrdude -c gpio -p m328p -U hfuse:w:0xDA:m
 	sudo avrdude -c gpio -p m328p -U efuse:w:0x05:m

--- a/Firmware/gopigo_firmware_update.sh
+++ b/Firmware/gopigo_firmware_update.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
 REPO_PATH=$(readlink -f $(dirname $0) | grep -E -o "^(.*?\\GoPiGo)")
 update_gopigo_firmware(){ 
+	# Check if this function is called from a Dexter script like
+	# /Raspbian_For_Robots/upd_script/update_GoPiGo_Firmware.sh
 	if [[ "$1" == "Dexter" ]]
 	then
 	    REPO_PATH=/home/pi/Dexter/GoPiGo
+	fi
+	# Checking if the REPO_PATH contains GoPiGo folder
+	if ! echo "$REPO_PATH" | grep -q "/GoPiGo"
+	then
+	    echo "Error in REPO_PATH:$REPO_PATH"
+	    exit
 	fi
 	echo "$REPO_PATH"
 	sudo avrdude -c gpio -p m328p -U lfuse:w:0x7F:m

--- a/Firmware/gopigo_firmware_update.sh
+++ b/Firmware/gopigo_firmware_update.sh
@@ -13,7 +13,7 @@ update_gopigo_firmware(){
 	    echo "Error in REPO_PATH:$REPO_PATH"
 	    exit
 	fi
-	echo "$REPO_PATH"
+	echo "GoPiGo is found at :$REPO_PATH"
 	sudo avrdude -c gpio -p m328p -U lfuse:w:0x7F:m
 	sudo avrdude -c gpio -p m328p -U hfuse:w:0xDA:m
 	sudo avrdude -c gpio -p m328p -U efuse:w:0x05:m


### PR DESCRIPTION
Here https://github.com/DexterInd/Raspbian_For_Robots/blob/master/upd_script/update_GoPiGo_Firmware.sh#L56 when update_gopigo_firmware is called from "update_GoPiGo_Firmware.sh" the command here https://github.com/DexterInd/GoPiGo/blob/master/Firmware/gopigo_firmware_update.sh#L2 looks for a GoPiGo folder from the path of the file that called it. In case of "~/home/pi/di_update/Raspbian_For_Robots/upd_script/update_GoPiGo_Firmware.sh" there is no GoPiGo folder in its path. Hence update fails. This PR solves it.