### PR TITLE
reduce lag when importing [easygopigo.py] module

### DIFF
--- a/Software/Python/gopigo.py
+++ b/Software/Python/gopigo.py
@@ -127,14 +127,30 @@ LED_R=0
 # This allows us to be more specific about which commands contain unused bytes
 unused = 0
 
-v16_thresh=790
-
 '''
 #Enable slow i2c (for better stability)
 def en_slow_i2c():
 	#subprocess.call('sudo rmmod i2c_bcm2708',shell=True)
 	subprocess.call('sudo modprobe i2c_bcm2708 baudrate=70000',shell=True)
 '''
+
+# if the value of this following variable is None, then it means the HW version hasn't been checked yet
+# in order to be checked, we use check_hw_version() function
+gopigo_hwversion = None
+
+def check_hw_version():
+    hw_version = None
+    v16_thresh = 790
+
+    for i in range(10):
+        raw = analogRead(7)
+
+    if raw > v16_thresh:
+        hw_version = 16
+    else:
+        hw_version = 14
+
+    return hw_version
 
 #Write I2C block
 def write_i2c_block(address,block):
@@ -445,7 +461,11 @@ def read_motor_speed():
 #	arg:
 #		l_id: 1 for left LED and 0 for right LED
 def led_on(l_id):
-	if version > 14:
+    global gopigo_hwversion
+    if gopigo_hwversion is None:
+        gopigo_hwversion = check_hw_version()
+
+	if gopigo_hwversion > 14:
 		r_led=16
 		l_led=17
 	else:
@@ -467,7 +487,11 @@ def led_on(l_id):
 #	arg:
 #		l_id: 1 for left LED and 0 for right LED
 def led_off(l_id):
-	if version>14:
+    global gopigo_hwversion
+    if gopigo_hwversion is None:
+        gopigo_hwversion = check_hw_version()
+
+	if gopigo_hwversion > 14:
 		r_led=16
 		l_led=17
 	else:
@@ -658,11 +682,3 @@ def dht(sensor_type=0):
 			return [-2.0,-2.0]
 	except RuntimeError:
 		return [-3.0,-3.0]
-
-for i in range(10):
-	raw=analogRead(7)
-
-if raw>v16_thresh:
-	version=16
-else:
-	version=14


### PR DESCRIPTION
The time to import `easygopigo.py` library is on average at `0.8-1.1 seconds` - which is a lot.

Here's a screenshot of the time it takes to import. 
The orange arrow points to the total time it takes to import the library. 
Surprisingly, in this example it takes less - maybe that's because I'm executing it and not importing it.
Don't worry, I've removed the `if __name__ == '__main__'` block so that it doesn't execute when I run and profile the script.
![Imgur](http://i.imgur.com/Vc0Ogel.jpg)

For the moment, I've reduced the time to import the `gopigo.py` module (which is imported by `easygopigo.py` module).
Whenever `gopigo.py` was imported, the script would check the HW version of the `GoPiGo` by doing 10 `analogRead`s - which is a lot. In this profile log, it seems that the import of `gopigo.py` module takes *22%* of the total time to execute the `easygopigo.py` module, which is a lot (it means roughly `140 ms`).

This PR isn't ready to be merged yet. I need some time to check if I can cut some more time out of the import time.
Also, I need to test it so I can be sure there ain't a syntax error somewhere - *you know, those tab spaces .. doh*

@Nicole also said that she's moving out the camera import out of `easygopigo.py` module, so she's already cutting more time.