### PR TITLE
hotfix - erratic values when reading from [line follower]

### DIFF
--- a/Setup/install.sh
+++ b/Setup/install.sh
@@ -33,7 +33,7 @@ echo "  ______  _____   _____  _____  ______  _____ "
 echo " |  ____ |     | |_____]   |   |  ____ |     |"
 echo " |_____| |_____| |       __|__ |_____| |_____|"
 echo " "
-feedback "Welcome to GoPiGo Installer." 
+feedback "Welcome to GoPiGo Installer."
 echo " "
 }
 
@@ -49,7 +49,7 @@ check_internet() {
     if ! quiet_mode ; then
         feedback "Check for internet connectivity..."
         feedback "=================================="
-        wget -q --tries=2 --timeout=20 --output-document=/dev/null http://raspberrypi.org 
+        wget -q --tries=2 --timeout=20 --output-document=/dev/null http://raspberrypi.org
         if [ $? -eq 0 ];then
             echo "Connected to the Internet"
         else
@@ -80,7 +80,8 @@ install_dependencies() {
     sudo apt-get install python-pip git libi2c-dev python-serial python-rpi.gpio i2c-tools python-smbus arduino minicom libnss-mdns python-dev -y
     sudo pip install -U RPi.GPIO
     sudo pip install pyusb
-    
+    sudo pip install numpy
+
     feedback "Dependencies installed"
 }
 
@@ -97,7 +98,7 @@ install_wiringpi() {
     # Check if WiringPi Installed
 
     # using curl piped to bash does not leave a file behind. no need to remove it
-    # we can do either the curl - it works just fine 
+    # we can do either the curl - it works just fine
     # sudo curl https://raw.githubusercontent.com/DexterInd/script_tools/master/update_wiringpi.sh | bash
     # or call the version that's already on the SD card
     sudo bash $DEXTERSCRIPT/update_wiringpi.sh
@@ -162,7 +163,7 @@ install_spi_i2c() {
 }
 
 install_avr() {
-    #Adding ARDUINO setup files 
+    #Adding ARDUINO setup files
     echo " "
 	######################################################################
 	# Remove after the image is created for BrickPi3
@@ -198,11 +199,11 @@ install_line_follower(){
     sudo cp /home/pi/Dexter/GoPiGo/Software/Python/line_follower/line_follow.desktop /home/pi/Desktop/
     sudo chmod +x /home/pi/Desktop/line_follow.desktop
     sudo chmod +x /home/pi/Dexter/GoPiGo/Software/Python/line_follower/line_sensor_gui.py
-    
+
     # if the configuration files exist in the home directory
     # then move them to their new place
     # otherwise create new ones
-    if file_exists "$PIHOME/black_line.txt" 
+    if file_exists "$PIHOME/black_line.txt"
     then
         sudo mv $PIHOME/black_line.txt $PIHOME/Dexter/black_line.txt
     else
@@ -214,13 +215,13 @@ install_line_follower(){
         sudo mv $PIHOME/white_line.txt $PIHOME/Dexter/white_line.txt
     else
         sudo touch $PIHOME/Dexter/white_line.txt
-    fi    
+    fi
     if file_exists "$PIHOME/range_line.txt"
     then
         sudo mv $PIHOME/range_line.txt $PIHOME/Dexter/range_line.txt
     else
         sudo touch $PIHOME/Dexter/range_line.txt
-    fi      
+    fi
 
     sudo chmod 666 $PIHOME/Dexter/*line.txt
 
@@ -265,7 +266,7 @@ install_dependencies
 #Copy Software Servo
 cp -R $ROBOT_DIR/Firmware/SoftwareServo/ /usr/share/arduino/libraries/
 
-chmod +x gopigo 
+chmod +x gopigo
 cp gopigo /usr/bin
 
 cd $ROBOT_DIR/Software/Python

--- a/Software/Python/line_follower/line_sensor.py
+++ b/Software/Python/line_follower/line_sensor.py
@@ -85,8 +85,8 @@ file_r=dir_path+'range_line.txt'
 
 # buffer for the lien follower sensor
 sensor_buffer = [ [], [], [], [], [] ]
-# keep a maximum of 15 readings for each IR sensor on the line follower
-max_buffer_length = 15
+# keep a maximum of 20 readings for each IR sensor on the line follower
+max_buffer_length = 20
 
 # Function for removing outlier values
 # For bigger std_factor_threshold, the filtering is less aggressive
@@ -137,8 +137,8 @@ def read_sensor():
                 sensor_buffer[i].pop(0)
 
             # eliminate outlier values and select the most recent one
-            filtered_value = statisticalNoiseReduction(sensor_buffer[i], 1.5)[-1]
-            
+            filtered_value = statisticalNoiseReduction(sensor_buffer[i], 2)[-1]
+
             # append the value to the corresponding IR sensor
             output_values.append(filtered_value)
 

--- a/Software/Python/line_follower/line_sensor.py
+++ b/Software/Python/line_follower/line_sensor.py
@@ -83,7 +83,7 @@ file_r=dir_path+'range_line.txt'
 # Function declarations of the various functions used for encoding and sending
 # data from RPi to Arduino
 
-# buffer for the lien follower sensor
+# buffer with raw data from the line follower sensor
 sensor_buffer = [ [], [], [], [], [] ]
 # keep a maximum of 20 readings for each IR sensor on the line follower
 max_buffer_length = 20

--- a/Software/Python/line_follower/line_sensor.py
+++ b/Software/Python/line_follower/line_sensor.py
@@ -42,6 +42,7 @@ import RPi.GPIO as GPIO
 import struct
 import operator
 import pickle
+import numpy
 
 debug =0
 
@@ -82,6 +83,33 @@ file_r=dir_path+'range_line.txt'
 # Function declarations of the various functions used for encoding and sending
 # data from RPi to Arduino
 
+# buffer for the lien follower sensor
+sensor_buffer = [ [], [], [], [], [] ]
+# keep a maximum of 15 readings for each IR sensor on the line follower
+max_buffer_length = 15
+
+# Function for removing outlier values
+# For bigger std_factor_threshold, the filtering is less aggressive
+# For smaller std_factor_threshold, the filtering is more aggressive
+# std_factor_threshold must be bigger than 0
+def statisticalNoiseReduction(values, std_factor_threshold = 2):
+    if len(values) == 0:
+    	return []
+
+    mean = numpy.mean(values)
+    standard_deviation = numpy.std(values)
+
+    # just return if we only got constant values
+    if standard_deviation == 0:
+    	return values
+
+    # remove outlier values which are less than the average but bigger than the calculated threshold
+    filtered_values = [element for element in values if element > mean - std_factor_threshold * standard_deviation]
+    # the same but in the opposite direction
+    filtered_values = [element for element in filtered_values if element < mean + std_factor_threshold * standard_deviation]
+
+    return filtered_values
+
 # Write I2C block
 def write_i2c_block(address, block):
 	try:
@@ -91,22 +119,33 @@ def write_i2c_block(address, block):
 			print ("IOError")
 		return -1
 
-
+# Function for reading line follower's values off of its IR sensor
 def read_sensor():
-	try:
-		#if sensor>=0 and sensor <=4:
-		bus.write_i2c_block_data(address, 1, aRead_cmd + [unused, unused, unused])
-		#time.sleep(.1)
-		#bus.read_byte(address)
-		number = bus.read_i2c_block_data(address, 1)
-		#time.sleep(.05)
-		return number[0]* 256 + number[1],number[2]* 256 + number[3],number[4]* 256 + number[5],number[6]* 256 + number[7],number[8]* 256 + number[9]
+    try:
+        output_values = []
+        bus.write_i2c_block_data(address, 1, aRead_cmd + [unused, unused, unused])
+        number = bus.read_i2c_block_data(address, 1)
 
-		#return number[0]* 256 + number[1]
+        # for each IR sensor on the line follower
+        for i in range(5):
+            # calculate the 2-byte number we got
+            sensor_buffer[i].append(number[2 * i] * 256 + number[2 * i + 1])
 
-		time.sleep(.05)
-	except IOError:
-		return -1,-1,-1,-1,-1
+            # if there're too many elements in the list
+            # then remove one
+            if len(sensor_buffer[i]) > max_buffer_length:
+                sensor_buffer[i].pop(0)
+
+            # eliminate outlier values and select the most recent one
+            filtered_value = statisticalNoiseReduction(sensor_buffer[i], 1.5)[-1]
+            
+            # append the value to the corresponding IR sensor
+            output_values.append(filtered_value)
+
+        return output_values
+
+    except IOError:
+        return 5 * [-1]
 
 
 def get_sensorval():


### PR DESCRIPTION
The `line follower` sensor is known for throwing erratic values from time to time.
I've been investigating and I'm almost sure that there's something within the line follower's firmware that sends these (maybe overflowed) values.

This is what we were getting before :
![erratic_values](https://user-images.githubusercontent.com/26958764/27494215-8e158c34-5855-11e7-8205-8700cbc488a4.PNG)
Also, this wasn't the only erratic value we got - there were others which were around `2800`, `6500`, `26000`, etc.

I've implemented the "old" statistical filtering function from the `DHT's` code.
I've had to tweak the following variables in order to get the desired results (I mean about removing the outlier values):

-  `max_buffer_length` - it's an integer and it specifies the buffer length of the list in which we store the values from the sensors.

- `std_factor_threshold` argument - it's a float and the smaller it is, the less aggressive the filtering process is. It's also valid vice-versa. 

 -----------

- [x] Tested by author.

- [ ] Tested by team.