### PR TITLE
Bring Distance Sensor in line with new API

### DIFF
--- a/Software/Python/easygopigo.py
+++ b/Software/Python/easygopigo.py
@@ -758,7 +758,7 @@ try:
             while (mm > 8000 or mm < 5) and attempt < 3:
                 _grab_read()
                 try:
-                    mm = self.readRangeSingleMillimeters()
+                    mm = self.self.read_range_single()
                 except:
                     mm = 0
                 _release_read()

--- a/Software/Python/easygopigo.py
+++ b/Software/Python/easygopigo.py
@@ -758,7 +758,7 @@ try:
             while (mm > 8000 or mm < 5) and attempt < 3:
                 _grab_read()
                 try:
-                    mm = self.self.read_range_single()
+                    mm = self.read_range_single()
                 except:
                     mm = 0
                 _release_read()


### PR DESCRIPTION
readRangeSingleMillimeters() no longer exists
Now use self.read_range_single()