### PR TITLE
Install valid line follower files when installing, instead of blank ones

### DIFF
--- a/Setup/install.sh
+++ b/Setup/install.sh
@@ -207,20 +207,20 @@ install_line_follower(){
     then
         sudo mv $PIHOME/black_line.txt $PIHOME/Dexter/black_line.txt
     else
-        sudo touch $PIHOME/Dexter/black_line.txt
+        sudo cp $PIHOME/Dexter/GoPiGo/Software/Python/line_follower/black_line.txt $PIHOME/Dexter/black_line.txt
     fi
 
     if file_exists "$PIHOME/white_line.txt"
     then
         sudo mv $PIHOME/white_line.txt $PIHOME/Dexter/white_line.txt
     else
-        sudo touch $PIHOME/Dexter/white_line.txt
+        sudo cp $PIHOME/Dexter/GoPiGo/Software/Python/line_follower/white_line.txt $PIHOME/Dexter/white_line.txt
     fi
     if file_exists "$PIHOME/range_line.txt"
     then
         sudo mv $PIHOME/range_line.txt $PIHOME/Dexter/range_line.txt
     else
-        sudo touch $PIHOME/Dexter/range_line.txt
+        sudo cp $PIHOME/Dexter/GoPiGo/Software/Python/line_follower/range_line.txt $PIHOME/Dexter/range_line.txt
     fi
 
     sudo chmod 666 $PIHOME/Dexter/*line.txt

--- a/Software/Python/line_follower/line_sensor.py
+++ b/Software/Python/line_follower/line_sensor.py
@@ -166,7 +166,7 @@ def get_sensorval():
 
 
 def set_black_line():
-	global black_line,white_line,range_col
+	global black_line, white_line, range_col
 	for i in range(5):
 		val=read_sensor()
 	# print (val)


### PR DESCRIPTION
Blank files cause the code to crash - which requires try/except (already in, but missing on DexterOS)