### PR TITLE
hofix - install privileges

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ This repository contains source code, firmware and design materials for the GoPi
 
 # Quick Install
 
-For installing the GoPiGo package(s) with root privileges, use one of the following command:
+For installing the python package(s) of the GoPiGo with root privileges (except for anything else that comes with it), use one of the following command:
 ```
 sudo sh -c "curl -kL dexterindustries.com/update_gopigo | bash"
 ```
 
-In order to quick install the GoPiGo package(s) without root privileges, use the following command:
+In order to quick install the GoPiGo package(s) without root privileges (except for anything else that comes with it), use the following command:
 ```
 curl -kL dexterindustris.com/update_gopigo | bash
 ```

--- a/README.md
+++ b/README.md
@@ -12,9 +12,14 @@ This repository contains source code, firmware and design materials for the GoPi
 
 # Quick Install
 
-In order to quick install the `GoPiGo` repository, open up a terminal and type the following command:
+In order to quick install the `GoPiGo` repository, open up a terminal and choose from one of the following 2 commands:
 ```
-sudo curl -kL dexterindustries.com/update_gopigo | bash
+# for running the command with root privileges run
+sudo sh -c "curl -kL dexterindustries.com/update_gopigo | bash"
+```
+```
+# for running the command with user privileges run
+curl -kL dexterindustries.com/update_gopigo | bash
 ```
 The same command can be used for updating the `GoPiGo` to the latest version.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ sudo sh -c "curl -kL dexterindustries.com/update_gopigo | bash"
 
 In order to quick install the GoPiGo package(s) without root privileges (except for anything else that comes with it), use the following command:
 ```
-curl -kL dexterindustris.com/update_gopigo | bash
+curl -kL dexterindustries.com/update_gopigo | bash
 ```
 
 # See Also

--- a/README.md
+++ b/README.md
@@ -12,14 +12,9 @@ This repository contains source code, firmware and design materials for the GoPi
 
 # Quick Install
 
-In order to quick install the `GoPiGo` repository, open up a terminal and choose from one of the following 2 commands:
+In order to quick install the `GoPiGo` repository, open up a terminal and type the following command:
 ```
-# for running the command with root privileges run
-sudo sh -c "curl -kL dexterindustries.com/update_gopigo | bash"
-```
-```
-# for running the command with user privileges run
-curl -kL dexterindustries.com/update_gopigo | bash
+sudo curl -kL dexterindustries.com/update_gopigo | bash
 ```
 The same command can be used for updating the `GoPiGo` to the latest version.
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,15 @@ This repository contains source code, firmware and design materials for the GoPi
 
 # Quick Install
 
-In order to quick install the `GoPiGo` repository, open up a terminal and type the following command:
+For installing the GoPiGo package(s) with root privileges, use one of the following command:
 ```
-sudo curl -kL dexterindustries.com/update_gopigo | bash
+sudo sh -c "curl -kL dexterindustries.com/update_gopigo | bash"
 ```
-The same command can be used for updating the `GoPiGo` to the latest version.
+
+In order to quick install the GoPiGo package(s) without root privileges, use the following command:
+```
+curl -kL dexterindustris.com/update_gopigo | bash
+```
 
 # See Also
 

--- a/Setup/README.md
+++ b/Setup/README.md
@@ -2,14 +2,21 @@
 
 This is the install script for the GoPiGo which installs all the packages and libraries need for running the GoPiGo.
 
-For installing the GoPiGo you should only enter the following command:
+For installing the GoPiGo you should only enter one of the 2 following command(s):
 ```
-sudo curl -kL dexterindustries.com/update_gopigo | bash
+# for installing the python packages with root permissions (except anything else which will ran as root) run this
+sudo sh -c "curl -kL dexterindustries.com/update_tools | bash"
+
+# for installing the python packages with user permissions (except anything else which will ran as root) run this
+curl -kL dexterindustries.com/update_tools | bash
 ```
 
 Or if you want the classic way, you can clone the repository, change directory to this folder and then enter the following command:
 ```
+# for root privileges
 sudo bash install.sh
+
+# for user privileges
 ```
 
 Make sure that you are connected to the internet before starting.

--- a/Setup/install.sh
+++ b/Setup/install.sh
@@ -159,8 +159,8 @@ install_spi_i2c() {
     feedback "Making I2C changes in /boot/config.txt . . ."
     feedback "================================================"
 
-    echo dtparam=i2c1=on >> /boot/config.txt
-    echo dtparam=i2c_arm=on >> /boot/config.txt
+    sudo sh -c "echo dtparam=i2c1=on >> /boot/config.txt"
+    sudo sh -c "echo dtparam=i2c_arm=on >> /boot/config.txt"
 
     sudo adduser pi i2c
     echo " "
@@ -268,10 +268,10 @@ install_dependencies
 
 
 #Copy Software Servo
-cp -R $ROBOT_DIR/Firmware/SoftwareServo/ /usr/share/arduino/libraries/
+sudo cp -R $ROBOT_DIR/Firmware/SoftwareServo/ /usr/share/arduino/libraries/
 
-chmod +x gopigo
-cp gopigo /usr/bin
+sudo chmod +x gopigo
+sudo cp gopigo /usr/bin
 
 cd $ROBOT_DIR/Software/Python
 python setup.py install

--- a/Setup/install.sh
+++ b/Setup/install.sh
@@ -78,15 +78,14 @@ install_dependencies() {
     feedback "Installing Dependencies"
     feedback "======================="
     sudo apt-get install python-pip git libi2c-dev python-serial python-rpi.gpio i2c-tools python-smbus arduino minicom libnss-mdns python-dev -y
-    sudo pip install -U RPi.GPIO
-    sudo pip install pyusb
-    sudo pip install numpy
-    sudo pip install python-periphery==1.1.0
-    sudo pip3 install -U RPi.GPIO
-    sudo pip3 install pyusb
-    sudo pip3 install numpy
-    sudo pip3 install python-periphery==1.1.0
-
+    pip install -U RPi.GPIO
+    pip install pyusb
+    pip install numpy
+    pip install python-periphery==1.1.0
+    pip3 install -U RPi.GPIO
+    pip3 install pyusb
+    pip3 install numpy
+    pip3 install python-periphery==1.1.0
 
     feedback "Dependencies installed"
 }
@@ -95,8 +94,8 @@ install_DHT() {
     # Install the DHT library
     feedback "Installing DHT library"
     pushd $ROBOT_DIR/Software/Python/sensor_examples/dht/Adafruit_Python_DHT > /dev/null
-    sudo python setup.py install
-    sudo python3 setup.py install
+    python setup.py install
+    python3 setup.py install
     popd > /dev/null
 }
 

--- a/Setup/install.sh
+++ b/Setup/install.sh
@@ -72,20 +72,20 @@ display_welcome_msg() {
 
 install_dependencies() {
     if ! quiet_mode ; then
-        sudo apt-get update
+        apt-get update
     fi
     echo " "
     feedback "Installing Dependencies"
     feedback "======================="
-    sudo apt-get install python-pip git libi2c-dev python-serial python-rpi.gpio i2c-tools python-smbus arduino minicom libnss-mdns python-dev -y
-    sudo pip install -U RPi.GPIO
-    sudo pip install pyusb
-    sudo pip install numpy
-    sudo pip install python-periphery==1.1.0
-    sudo pip3 install -U RPi.GPIO
-    sudo pip3 install pyusb
-    sudo pip3 install numpy
-    sudo pip3 install python-periphery==1.1.0
+    apt-get install python-pip git libi2c-dev python-serial python-rpi.gpio i2c-tools python-smbus arduino minicom libnss-mdns python-dev -y
+    pip install -U RPi.GPIO
+    pip install pyusb
+    pip install numpy
+    pip install python-periphery==1.1.0
+    pip3 install -U RPi.GPIO
+    pip3 install pyusb
+    pip3 install numpy
+    pip3 install python-periphery==1.1.0
 
 
     feedback "Dependencies installed"
@@ -95,8 +95,8 @@ install_DHT() {
     # Install the DHT library
     feedback "Installing DHT library"
     pushd $ROBOT_DIR/Software/Python/sensor_examples/dht/Adafruit_Python_DHT > /dev/null
-    sudo python setup.py install
-    sudo python3 setup.py install
+    python setup.py install
+    python3 setup.py install
     popd > /dev/null
 }
 
@@ -107,13 +107,13 @@ install_wiringpi() {
     # we can do either the curl - it works just fine
     # sudo curl https://raw.githubusercontent.com/DexterInd/script_tools/master/update_wiringpi.sh | bash
     # or call the version that's already on the SD card
-    sudo bash $DEXTERSCRIPT/update_wiringpi.sh
+    bash $DEXTERSCRIPT/update_wiringpi.sh
     # done with WiringPi
 
     # remove wiringPi directory if present
     if [ -d wiringPi ]
     then
-        sudo rm -r wiringPi
+        rm -r wiringPi
     fi
     # End check if WiringPi installed
     echo " "
@@ -125,13 +125,13 @@ install_spi_i2c() {
     if grep -q "#blacklist i2c-bcm2708" /etc/modprobe.d/raspi-blacklist.conf; then
         echo "I2C already removed from blacklist"
     else
-        sudo sed -i -e 's/blacklist i2c-bcm2708/#blacklist i2c-bcm2708/g' /etc/modprobe.d/raspi-blacklist.conf
+        sed -i -e 's/blacklist i2c-bcm2708/#blacklist i2c-bcm2708/g' /etc/modprobe.d/raspi-blacklist.conf
         echo "I2C removed from blacklist"
     fi
     if grep -q "#blacklist spi-bcm2708" /etc/modprobe.d/raspi-blacklist.conf; then
         echo "SPI already removed from blacklist"
     else
-        sudo sed -i -e 's/blacklist spi-bcm2708/#blacklist spi-bcm2708/g' /etc/modprobe.d/raspi-blacklist.conf
+        sed -i -e 's/blacklist spi-bcm2708/#blacklist spi-bcm2708/g' /etc/modprobe.d/raspi-blacklist.conf
         echo "SPI removed from blacklist"
     fi
 
@@ -164,7 +164,7 @@ install_spi_i2c() {
     echo dtparam=i2c1=on >> /boot/config.txt
     echo dtparam=i2c_arm=on >> /boot/config.txt
 
-    sudo adduser pi i2c
+    adduser pi i2c
     echo " "
 }
 
@@ -211,30 +211,30 @@ install_line_follower(){
     # otherwise create new ones
     if file_exists "$PIHOME/black_line.txt"
     then
-        sudo mv $PIHOME/black_line.txt $PIHOME/Dexter/black_line.txt
+        mv $PIHOME/black_line.txt $PIHOME/Dexter/black_line.txt
     else
-        sudo cp $PIHOME/Dexter/GoPiGo/Software/Python/line_follower/black_line.txt $PIHOME/Dexter/black_line.txt
+        cp $PIHOME/Dexter/GoPiGo/Software/Python/line_follower/black_line.txt $PIHOME/Dexter/black_line.txt
     fi
 
     if file_exists "$PIHOME/white_line.txt"
     then
-        sudo mv $PIHOME/white_line.txt $PIHOME/Dexter/white_line.txt
+        mv $PIHOME/white_line.txt $PIHOME/Dexter/white_line.txt
     else
-        sudo cp $PIHOME/Dexter/GoPiGo/Software/Python/line_follower/white_line.txt $PIHOME/Dexter/white_line.txt
+        cp $PIHOME/Dexter/GoPiGo/Software/Python/line_follower/white_line.txt $PIHOME/Dexter/white_line.txt
     fi
     if file_exists "$PIHOME/range_line.txt"
     then
-        sudo mv $PIHOME/range_line.txt $PIHOME/Dexter/range_line.txt
+        mv $PIHOME/range_line.txt $PIHOME/Dexter/range_line.txt
     else
-        sudo cp $PIHOME/Dexter/GoPiGo/Software/Python/line_follower/range_line.txt $PIHOME/Dexter/range_line.txt
+        cp $PIHOME/Dexter/GoPiGo/Software/Python/line_follower/range_line.txt $PIHOME/Dexter/range_line.txt
     fi
 
-    sudo chmod 666 $PIHOME/Dexter/*line.txt
+    chmod 666 $PIHOME/Dexter/*line.txt
 
 }
 
 install_control_panel(){
-    sudo cp "$ROBOT_DIR/Software/Python/control_panel/gopigo_control_panel.desktop" $PIHOME/Desktop
+    cp "$ROBOT_DIR/Software/Python/control_panel/gopigo_control_panel.desktop" $PIHOME/Desktop
 }
 
 call_for_reboot() {

--- a/Setup/install.sh
+++ b/Setup/install.sh
@@ -39,8 +39,7 @@ echo " "
 
 check_root_user() {
     if [[ $EUID -ne 0 ]]; then
-        feedback "FAIL!  This script must be run as such: sudo ./install.sh"
-        exit 1
+        feedback "No root permissions: the update script will not install python libraries."
     fi
     echo " "
 }

--- a/Setup/install.sh
+++ b/Setup/install.sh
@@ -76,7 +76,7 @@ install_dependencies() {
     echo " "
     feedback "Installing Dependencies"
     feedback "======================="
-    sudo apt-get install python-pip git libi2c-dev python-serial python-rpi.gpio i2c-tools python-smbus arduino minicom libnss-mdns python-dev -y
+    sudo apt-get install python-pip git libi2c-dev python-serial python-rpi.gpio i2c-tools python-smbus arduino minicom libnss-mdns python-dev build-essential libffi-dev -y
     pip install -U RPi.GPIO
     pip install pyusb
     pip install numpy

--- a/Setup/install.sh
+++ b/Setup/install.sh
@@ -72,20 +72,20 @@ display_welcome_msg() {
 
 install_dependencies() {
     if ! quiet_mode ; then
-        apt-get update
+        sudo apt-get update
     fi
     echo " "
     feedback "Installing Dependencies"
     feedback "======================="
-    apt-get install python-pip git libi2c-dev python-serial python-rpi.gpio i2c-tools python-smbus arduino minicom libnss-mdns python-dev -y
-    pip install -U RPi.GPIO
-    pip install pyusb
-    pip install numpy
-    pip install python-periphery==1.1.0
-    pip3 install -U RPi.GPIO
-    pip3 install pyusb
-    pip3 install numpy
-    pip3 install python-periphery==1.1.0
+    sudo apt-get install python-pip git libi2c-dev python-serial python-rpi.gpio i2c-tools python-smbus arduino minicom libnss-mdns python-dev -y
+    sudo pip install -U RPi.GPIO
+    sudo pip install pyusb
+    sudo pip install numpy
+    sudo pip install python-periphery==1.1.0
+    sudo pip3 install -U RPi.GPIO
+    sudo pip3 install pyusb
+    sudo pip3 install numpy
+    sudo pip3 install python-periphery==1.1.0
 
 
     feedback "Dependencies installed"
@@ -95,8 +95,8 @@ install_DHT() {
     # Install the DHT library
     feedback "Installing DHT library"
     pushd $ROBOT_DIR/Software/Python/sensor_examples/dht/Adafruit_Python_DHT > /dev/null
-    python setup.py install
-    python3 setup.py install
+    sudo python setup.py install
+    sudo python3 setup.py install
     popd > /dev/null
 }
 
@@ -107,13 +107,13 @@ install_wiringpi() {
     # we can do either the curl - it works just fine
     # sudo curl https://raw.githubusercontent.com/DexterInd/script_tools/master/update_wiringpi.sh | bash
     # or call the version that's already on the SD card
-    bash $DEXTERSCRIPT/update_wiringpi.sh
+    sudo bash $DEXTERSCRIPT/update_wiringpi.sh
     # done with WiringPi
 
     # remove wiringPi directory if present
     if [ -d wiringPi ]
     then
-        rm -r wiringPi
+        sudo rm -r wiringPi
     fi
     # End check if WiringPi installed
     echo " "
@@ -125,13 +125,13 @@ install_spi_i2c() {
     if grep -q "#blacklist i2c-bcm2708" /etc/modprobe.d/raspi-blacklist.conf; then
         echo "I2C already removed from blacklist"
     else
-        sed -i -e 's/blacklist i2c-bcm2708/#blacklist i2c-bcm2708/g' /etc/modprobe.d/raspi-blacklist.conf
+        sudo sed -i -e 's/blacklist i2c-bcm2708/#blacklist i2c-bcm2708/g' /etc/modprobe.d/raspi-blacklist.conf
         echo "I2C removed from blacklist"
     fi
     if grep -q "#blacklist spi-bcm2708" /etc/modprobe.d/raspi-blacklist.conf; then
         echo "SPI already removed from blacklist"
     else
-        sed -i -e 's/blacklist spi-bcm2708/#blacklist spi-bcm2708/g' /etc/modprobe.d/raspi-blacklist.conf
+        sudo sed -i -e 's/blacklist spi-bcm2708/#blacklist spi-bcm2708/g' /etc/modprobe.d/raspi-blacklist.conf
         echo "SPI removed from blacklist"
     fi
 
@@ -164,7 +164,7 @@ install_spi_i2c() {
     echo dtparam=i2c1=on >> /boot/config.txt
     echo dtparam=i2c_arm=on >> /boot/config.txt
 
-    adduser pi i2c
+    sudo adduser pi i2c
     echo " "
 }
 
@@ -211,30 +211,30 @@ install_line_follower(){
     # otherwise create new ones
     if file_exists "$PIHOME/black_line.txt"
     then
-        mv $PIHOME/black_line.txt $PIHOME/Dexter/black_line.txt
+        sudo mv $PIHOME/black_line.txt $PIHOME/Dexter/black_line.txt
     else
-        cp $PIHOME/Dexter/GoPiGo/Software/Python/line_follower/black_line.txt $PIHOME/Dexter/black_line.txt
+        sudo cp $PIHOME/Dexter/GoPiGo/Software/Python/line_follower/black_line.txt $PIHOME/Dexter/black_line.txt
     fi
 
     if file_exists "$PIHOME/white_line.txt"
     then
-        mv $PIHOME/white_line.txt $PIHOME/Dexter/white_line.txt
+        sudo mv $PIHOME/white_line.txt $PIHOME/Dexter/white_line.txt
     else
-        cp $PIHOME/Dexter/GoPiGo/Software/Python/line_follower/white_line.txt $PIHOME/Dexter/white_line.txt
+        sudo cp $PIHOME/Dexter/GoPiGo/Software/Python/line_follower/white_line.txt $PIHOME/Dexter/white_line.txt
     fi
     if file_exists "$PIHOME/range_line.txt"
     then
-        mv $PIHOME/range_line.txt $PIHOME/Dexter/range_line.txt
+        sudo mv $PIHOME/range_line.txt $PIHOME/Dexter/range_line.txt
     else
-        cp $PIHOME/Dexter/GoPiGo/Software/Python/line_follower/range_line.txt $PIHOME/Dexter/range_line.txt
+        sudo cp $PIHOME/Dexter/GoPiGo/Software/Python/line_follower/range_line.txt $PIHOME/Dexter/range_line.txt
     fi
 
-    chmod 666 $PIHOME/Dexter/*line.txt
+    sudo chmod 666 $PIHOME/Dexter/*line.txt
 
 }
 
 install_control_panel(){
-    cp "$ROBOT_DIR/Software/Python/control_panel/gopigo_control_panel.desktop" $PIHOME/Desktop
+    sudo cp "$ROBOT_DIR/Software/Python/control_panel/gopigo_control_panel.desktop" $PIHOME/Desktop
 }
 
 call_for_reboot() {

--- a/Setup/update_gopigo.sh
+++ b/Setup/update_gopigo.sh
@@ -12,9 +12,9 @@ GOPIGO_DIR=$DEXTER_PATH/GoPiGo
 if folder_exists $GOPIGO_DIR; then
     echo "GoPiGo Directory Exists"
     cd $DEXTER_PATH/GoPiGo  # Go to directory
-    sudo git fetch origin       # Hard reset the git files
-    sudo git reset --hard
-    sudo git merge origin/master
+    git fetch origin       # Hard reset the git files
+    git reset --hard
+    git merge origin/master
 else
     cd $DEXTER_PATH
     git clone https://github.com/DexterInd/GoPiGo
@@ -25,5 +25,5 @@ change_branch  $BRANCH # change to a branch we're working on.
 pushd $DEXTER_PATH/GoPiGo/Setup > /dev/null
 feedback "--> UPDATING LIBRARIES"
 feedback "------------------"
-sudo bash ./install.sh
+bash ./install.sh
 popd > /dev/null

--- a/Setup/update_gopigo.sh
+++ b/Setup/update_gopigo.sh
@@ -25,5 +25,5 @@ change_branch  $BRANCH # change to a branch we're working on.
 pushd $DEXTER_PATH/GoPiGo/Setup > /dev/null
 feedback "--> UPDATING LIBRARIES"
 feedback "------------------"
-sudo bash ./install.sh
+bash ./install.sh
 popd > /dev/null

--- a/Setup/update_gopigo.sh
+++ b/Setup/update_gopigo.sh
@@ -12,9 +12,9 @@ GOPIGO_DIR=$DEXTER_PATH/GoPiGo
 if folder_exists $GOPIGO_DIR; then
     echo "GoPiGo Directory Exists"
     cd $DEXTER_PATH/GoPiGo  # Go to directory
-    git fetch origin       # Hard reset the git files
-    git reset --hard
-    git merge origin/master
+    sudo git fetch origin       # Hard reset the git files
+    sudo git reset --hard
+    sudo git merge origin/master
 else
     cd $DEXTER_PATH
     git clone https://github.com/DexterInd/GoPiGo
@@ -25,5 +25,5 @@ change_branch  $BRANCH # change to a branch we're working on.
 pushd $DEXTER_PATH/GoPiGo/Setup > /dev/null
 feedback "--> UPDATING LIBRARIES"
 feedback "------------------"
-bash ./install.sh
+sudo bash ./install.sh
 popd > /dev/null

--- a/Software/Python/requirements.txt
+++ b/Software/Python/requirements.txt
@@ -1,1 +1,2 @@
 future
+smbus-cffi


### PR DESCRIPTION
This should make the GoPiGo update/install with or without privileges the python package(s).

For updating/installing the python packages of the GoPiGo **with** su privileges the user will run:
```
# this
sudo sh -c "curl -kL dexterindustries.com/update_gopigo | bash"

# or this
curl -kL dexterindustries.com/update_gopigo > update_gopigo.sh
sudo bash update_gopigo.sh
```
For updating/installing the python packages of the GoPiGo **without** su privileges the user will run:
```
curl -kL dexterindustries.com/update_gopigo | bash
```

Further tests are still required. We need to make sure `Raspbian For Robots` still works fine, as-well as anything afferent and that `DexterOS` still works fine.