### PR TITLE
feature - make easy installation of the robot

### DIFF
--- a/Setup/README.md
+++ b/Setup/README.md
@@ -1,25 +1,32 @@
 ## Installing
 
-This is the install script for the GoPiGo which installs all the packages and libraries need for running the GoPiGo.
+You need internet access for the following step(s).
 
-For installing the GoPiGo you should only enter one of the 2 following command(s):
+The quickest way for installing the GoPiGo is to enter the following command:
 ```
-# for installing the python packages with root permissions (except anything else which will ran as root) run this
-sudo sh -c "curl -kL dexterindustries.com/update_tools | bash"
-
-# for installing the python packages with user permissions (except anything else which will ran as root) run this
-curl -kL dexterindustries.com/update_tools | bash
+curl -kL dexterindustries.com/update_gopigo | bash
 ```
 
-Or if you want the classic way, you can clone the repository, change directory to this folder and then enter the following command:
-```
-# for root privileges
-sudo bash install.sh
+By default, the GoPiGo package is installed system-wide and [script_tools](https://github.com/DexterInd/script_tools) is completely updated each time the script is ran.
 
-# for user privileges
+An example using options appended to the command can be:
+```
+curl -kL dexterindustries.com/update_gopigo | bash -s --user-local --no-update-aptget --no-dependencies
 ```
 
-Make sure that you are connected to the internet before starting.
+## Command Options
+
+The options that can be appended to this command are:
+
+* `--no-dependencies` - skip installing any dependencies for the GoPiGo. It's supposed to be used on each consecutive update after the initial install has gone through.
+* `--no-update-aptget` - to skip using `sudo apt-get update` before installing dependencies. For this to be useful, `--no-dependencies` has to be not used.
+* `--bypass-pkg-scriptools` - skips installing/updating the python package for  [script_tools](https://github.com/DexterInd/script_tools).
+* `--user-local` - install the python package for the GoPiGo in the home directory of the user. This doesn't require any special read/write permissions: the actual command used is (`python setup.py install --force --user`).
+* `--env-local` - install the python package for the GoPiGo within the given environment without elevated privileges: the actual command used is (`python setup.py install --force`).
+* `--system-wide` - install the python package for the GoPiGo within the sytem-wide environment with `sudo`: the actual command used is (`sudo python setup.py install --force`).
+
+Important to remember is that `--user-local`, `--env-local` and `--system-wide` options are all mutually-exclusive - they cannot be used together.
+As a last thing, different versions of it can be pulled by appending a corresponding branch name or tag.
 
 ## License
 GoPiGo for the Raspberry Pi: an open source robotics platform for the Raspberry Pi.

--- a/Setup/install.sh
+++ b/Setup/install.sh
@@ -44,15 +44,6 @@ check_root_user() {
     echo " "
 }
 
-install_DHT() {
-    # Install the DHT library
-    feedback "Installing DHT library"
-    pushd $ROBOT_DIR/Software/Python/sensor_examples/dht/Adafruit_Python_DHT > /dev/null
-    python setup.py install --force
-    python3 setup.py install --force
-    popd > /dev/null
-}
-
 install_wiringpi() {
     # Check if WiringPi Installed
 
@@ -130,23 +121,12 @@ install_control_panel() {
 
 check_root_user
 install_dependencies
-
 # copy software servo
 sudo cp -R $ROBOT_DIR/Firmware/SoftwareServo/ /usr/share/arduino/libraries/
-
 # copy gopigo executable
 # the gopigo executable is for reporting data about the gopigo board
 sudo chmod +x gopigo
 sudo cp gopigo /usr/bin
-
-# remove old libraries, as Mutex is being searched in here instead of
-# the proper place
-sudo pip uninstall gopigo -y
-sudo pip3 uninstall gopigo -y
-cd $ROBOT_DIR/Software/Python
-python setup.py install --force
-python3 setup.py install --force
-
 install_DHT
 install_wiringpi
 install_spi_i2c

--- a/Setup/install.sh
+++ b/Setup/install.sh
@@ -76,6 +76,7 @@ install_spi_i2c() {
 
 install_avr() {
   feedback "Installing avrdude for the GoPiGo"
+	source $DEXTERSCRIPT/install_avrdude.sh
   create_avrdude_folder
   install_avrdude
   cd $ROBOT_DIR

--- a/Setup/install.sh
+++ b/Setup/install.sh
@@ -104,6 +104,15 @@ install_spi_i2c() {
     echo " "
 }
 
+install_avr() {
+  feedback "Installing avrdude"
+  feedback "=================="
+  create_avrdude_folder
+  install_avrdude
+  cd $ROBOT_DIR
+  echo "done with AVRDUDE "
+}
+
 install_control_panel() {
     sudo cp "$ROBOT_DIR/Software/Python/control_panel/gopigo_control_panel.desktop" $PIHOME/Desktop
 }
@@ -124,6 +133,7 @@ sudo chmod +x gopigo
 sudo cp gopigo /usr/bin
 install_wiringpi
 install_spi_i2c
+install_avr
 install_control_panel
 
 sudo chmod +x $ROBOT_DIR/Software/Scratch/GoPiGo_Scratch_Scripts/*.sh

--- a/Setup/install.sh
+++ b/Setup/install.sh
@@ -7,9 +7,7 @@ DEXTERSCRIPT=$PIHOME/Dexter/lib/Dexter/script_tools
 source $DEXTERSCRIPT/functions_library.sh
 
 display_welcome_msg() {
-  echo " "
 	echo "Special thanks to Joe Sanford at Tufts University. This script was derived from his work. Thank you Joe!"
-  echo " "
 }
 
 install_dependencies() {
@@ -18,14 +16,12 @@ install_dependencies() {
     # done by the script_tools installer in
     # update_gopigo.sh
 
-    echo " "
-    feedback "Installing Dependencies"
-    feedback "======================="
+    feedback "Installing dependencies for the GoPiGo"
     sudo apt-get install git libi2c-dev  i2c-tools minicom libnss-mdns build-essential libffi-dev -y
     sudo apt-get install python-pip python-serial python-rpi.gpio python-smbus python-dev python-numpy -y
     sudo apt-get install python3-pip python3-serial python3-rpi.gpio python3-smbus python3-dev python3-numpy -y
 
-    feedback "Dependencies installed"
+    feedback "Dependencies installed for the GoPiGo"
 }
 
 check_root_user() {
@@ -36,28 +32,8 @@ check_root_user() {
     echo " "
 }
 
-install_wiringpi() {
-    # Check if WiringPi Installed
-
-    # using curl piped to bash does not leave a file behind. no need to remove it
-    # we can do either the curl - it works just fine
-    # sudo curl https://raw.githubusercontent.com/DexterInd/script_tools/master/update_wiringpi.sh | bash
-    # or call the version that's already on the SD card
-    sudo bash $DEXTERSCRIPT/update_wiringpi.sh
-    # done with WiringPi
-
-    # remove wiringPi directory if present
-    if [ -d wiringPi ]
-    then
-        sudo rm -r wiringPi
-    fi
-    # End check if WiringPi installed
-    echo " "
-}
-
 install_spi_i2c() {
     feedback "Removing blacklist from /etc/modprobe.d/raspi-blacklist.conf . . ."
-    feedback "=================================================================="
     if grep -q "#blacklist i2c-bcm2708" /etc/modprobe.d/raspi-blacklist.conf; then
         echo "I2C already removed from blacklist"
     else
@@ -74,7 +50,6 @@ install_spi_i2c() {
     #Adding in /etc/modules
     echo " "
     feedback "Adding I2C-dev and SPI-dev in /etc/modules . . ."
-    feedback "================================================"
     if grep -q "i2c-dev" /etc/modules; then
         echo "I2C-dev already there"
     else
@@ -95,7 +70,6 @@ install_spi_i2c() {
     fi
     echo " "
     feedback "Making I2C changes in /boot/config.txt . . ."
-    feedback "================================================"
 
     sudo sh -c "echo dtparam=i2c1=on >> /boot/config.txt"
     sudo sh -c "echo dtparam=i2c_arm=on >> /boot/config.txt"
@@ -105,8 +79,7 @@ install_spi_i2c() {
 }
 
 install_avr() {
-  feedback "Installing avrdude"
-  feedback "=================="
+  feedback "Installing avrdude for the GoPiGo"
   create_avrdude_folder
   install_avrdude
   cd $ROBOT_DIR
@@ -131,7 +104,6 @@ install_dependencies
 # the gopigo executable is for reporting data about the gopigo board
 sudo chmod +x gopigo
 sudo cp gopigo /usr/bin
-install_wiringpi
 install_spi_i2c
 install_avr
 install_control_panel

--- a/Setup/install.sh
+++ b/Setup/install.sh
@@ -29,7 +29,6 @@ check_root_user() {
         feedback "FAIL!  This script must be run as such: sudo ./install.sh"
         exit 1
     fi
-    echo " "
 }
 
 install_spi_i2c() {
@@ -48,7 +47,6 @@ install_spi_i2c() {
     fi
 
     #Adding in /etc/modules
-    echo " "
     feedback "Adding I2C-dev and SPI-dev in /etc/modules . . ."
     if grep -q "i2c-dev" /etc/modules; then
         echo "I2C-dev already there"
@@ -68,14 +66,12 @@ install_spi_i2c() {
         echo spi-dev >> /etc/modules
         echo "spi-dev added"
     fi
-    echo " "
     feedback "Making I2C changes in /boot/config.txt . . ."
 
     sudo sh -c "echo dtparam=i2c1=on >> /boot/config.txt"
     sudo sh -c "echo dtparam=i2c_arm=on >> /boot/config.txt"
 
     sudo adduser pi i2c
-    echo " "
 }
 
 install_avr() {

--- a/Setup/install.sh
+++ b/Setup/install.sh
@@ -23,7 +23,7 @@ install_dependencies() {
     feedback "======================="
     sudo apt-get install git libi2c-dev  i2c-tools minicom libnss-mdns build-essential libffi-dev -y
     sudo apt-get install python-pip python-serial python-rpi.gpio python-smbus python-dev python-numpy -y
-    sudo apt-get install python3-pip python3-serial python3-rpi.gpio python3-smbus python3-dev python-numpy3 -y
+    sudo apt-get install python3-pip python3-serial python3-rpi.gpio python3-smbus python3-dev python3-numpy -y
 
     feedback "Dependencies installed"
 }
@@ -113,13 +113,15 @@ install_control_panel() {
 
 check_root_user
 install_dependencies
+
 # copy software servo
-sudo cp -R $ROBOT_DIR/Firmware/SoftwareServo/ /usr/share/arduino/libraries/
+# we might also want to delete $ROBOT_DIR/Firmware/SoftwareServo from the repo for good
+# sudo cp -R $ROBOT_DIR/Firmware/SoftwareServo/ /usr/share/arduino/libraries/
+
 # copy gopigo executable
 # the gopigo executable is for reporting data about the gopigo board
 sudo chmod +x gopigo
 sudo cp gopigo /usr/bin
-install_DHT
 install_wiringpi
 install_spi_i2c
 install_control_panel

--- a/Setup/install.sh
+++ b/Setup/install.sh
@@ -17,7 +17,7 @@ install_dependencies() {
     # update_gopigo.sh
 
     feedback "Installing dependencies for the GoPiGo"
-    sudo apt-get install git libi2c-dev  i2c-tools minicom libnss-mdns build-essential libffi-dev -y
+    sudo apt-get install git libi2c-dev i2c-tools minicom libnss-mdns build-essential libffi-dev -y
     sudo apt-get install python-pip python-serial python-rpi.gpio python-smbus python-dev python-numpy -y
     sudo apt-get install python3-pip python3-serial python3-rpi.gpio python3-smbus python3-dev python3-numpy -y
 

--- a/Setup/install.sh
+++ b/Setup/install.sh
@@ -22,16 +22,8 @@ install_dependencies() {
     feedback "Installing Dependencies"
     feedback "======================="
     sudo apt-get install git libi2c-dev  i2c-tools minicom libnss-mdns build-essential libffi-dev -y
-    sudo apt-get install python-pip python-serial python-rpi.gpio python-smbus python-dev -y
-    sudo apt-get install python3-pip python3-serial python3-rpi.gpio python3-smbus python3-dev -y
-    sudo pip install -U RPi.GPIO
-    sudo pip install pyusb
-    sudo pip install numpy
-    sudo pip install python-periphery==1.1.0
-    sudo pip3 install -U RPi.GPIO
-    sudo pip3 install pyusb
-    sudo pip3 install numpy
-    sudo pip3 install python-periphery==1.1.0
+    sudo apt-get install python-pip python-serial python-rpi.gpio python-smbus python-dev python-numpy -y
+    sudo apt-get install python3-pip python3-serial python3-rpi.gpio python3-smbus python3-dev python-numpy3 -y
 
     feedback "Dependencies installed"
 }

--- a/Setup/install.sh
+++ b/Setup/install.sh
@@ -1,6 +1,4 @@
 #! /bin/bash
-curl --silent https://raw.githubusercontent.com/DexterInd/script_tools/master/install_script_tools.sh | bash
-
 SCRIPT_DIR="$(readlink -f $(dirname $0))"
 ROBOT_DIR="${SCRIPT_DIR%/*}"
 PIHOME=/home/pi
@@ -8,86 +6,42 @@ DEXTERSCRIPT=$PIHOME/Dexter/lib/Dexter/script_tools
 
 source $DEXTERSCRIPT/functions_library.sh
 
-identify_cie() {
-    if ! quiet_mode
-    then
-        echo "  _____            _                                ";
-        echo " |  __ \          | |                               ";
-        echo " | |  | | _____  _| |_ ___ _ __                     ";
-        echo " | |  | |/ _ \ \/ / __/ _ \ '__|                    ";
-        echo " | |__| |  __/>  <| ||  __/ |                       ";
-        echo " |_____/ \___/_/\_\\\__\___|_|          _            ";
-        echo " |_   _|         | |         | |      (_)           ";
-        echo "   | |  _ __   __| |_   _ ___| |_ _ __ _  ___  ___  ";
-        echo "   | | | '_ \ / _\ | | | / __| __| '__| |/ _ \/ __| ";
-        echo "  _| |_| | | | (_| | |_| \__ \ |_| |  | |  __/\__ \ ";
-        echo " |_____|_| |_|\__,_|\__,_|___/\__|_|  |_|\___||___/ ";
-        echo "                                                    ";
-        echo "                                                    ";
-        echo " "
-    fi
+display_welcome_msg() {
+  echo " "
+	echo "Special thanks to Joe Sanford at Tufts University. This script was derived from his work. Thank you Joe!"
+  echo " "
 }
 
-identify_robot() {
-echo "  ______  _____   _____  _____  ______  _____ "
-echo " |  ____ |     | |_____]   |   |  ____ |     |"
-echo " |_____| |_____| |       __|__ |_____| |_____|"
-echo " "
-feedback "Welcome to GoPiGo Installer."
-echo " "
+install_dependencies() {
+
+    # the sudo apt-get update is already
+    # done by the script_tools installer in
+    # update_gopigo.sh
+
+    echo " "
+    feedback "Installing Dependencies"
+    feedback "======================="
+    sudo apt-get install git libi2c-dev  i2c-tools minicom libnss-mdns build-essential libffi-dev -y
+    sudo apt-get install python-pip python-serial python-rpi.gpio python-smbus python-dev -y
+    sudo apt-get install python3-pip python3-serial python3-rpi.gpio python3-smbus python3-dev -y
+    sudo pip install -U RPi.GPIO
+    sudo pip install pyusb
+    sudo pip install numpy
+    sudo pip install python-periphery==1.1.0
+    sudo pip3 install -U RPi.GPIO
+    sudo pip3 install pyusb
+    sudo pip3 install numpy
+    sudo pip3 install python-periphery==1.1.0
+
+    feedback "Dependencies installed"
 }
 
 check_root_user() {
     if [[ $EUID -ne 0 ]]; then
-        feedback "No root permissions: the update script will not install python libraries."
+        feedback "FAIL!  This script must be run as such: sudo ./install.sh"
+        exit 1
     fi
     echo " "
-}
-
-check_internet() {
-    if ! quiet_mode ; then
-        feedback "Check for internet connectivity..."
-        feedback "=================================="
-        wget -q --tries=2 --timeout=20 --output-document=/dev/null http://raspberrypi.org
-        if [ $? -eq 0 ];then
-            echo "Connected to the Internet"
-        else
-            echo "Unable to Connect, try again !!!"
-            exit 0
-        fi
-    fi
-}
-
-display_welcome_msg() {
-    feedback "Please ensure internet connectivity before running this script."
-    if ! quiet_mode
-    then
-        feedback "NOTE: Raspberry Pi will need to be rebooted after completion."
-    fi
-
-    feedback "Special thanks to Joe Sanford at Tufts University.  This script was derived from his work.  Thank you Joe!"
-    echo " "
-}
-
-install_dependencies() {
-    if ! quiet_mode ; then
-        sudo apt-get update
-    fi
-    echo " "
-    feedback "Installing Dependencies"
-    feedback "======================="
-    sudo apt-get install python-pip git libi2c-dev python-serial python-rpi.gpio i2c-tools python-smbus minicom libnss-mdns python-dev build-essential libffi-dev -y
-    pip install -U RPi.GPIO
-    pip install pyusb
-    pip install numpy
-    pip install python-periphery==1.1.0
-    pip3 install -U RPi.GPIO
-    pip3 install pyusb
-    pip3 install numpy
-    pip3 install python-periphery==1.1.0
-
-
-    feedback "Dependencies installed"
 }
 
 install_DHT() {
@@ -167,80 +121,25 @@ install_spi_i2c() {
     echo " "
 }
 
-install_avr() {
-    #Adding ARDUINO setup files
-    echo " "
-  	######################################################################
-  	# Remove after the image is created for BrickPi3
-  	######################################################################
-      # feedback "Making changes to Arduino . . ."
-      # feedback "==============================="
-      # cd /tmp
-      # wget http://project-downloads.drogon.net/gertboard/avrdude_5.10-4_armhf.deb
-      # sudo dpkg -i avrdude_5.10-4_armhf.deb
-      # sudo chmod 4755 /usr/bin/avrdude
-      # cd /tmp
-      # if [ -f /tmp/setup.sh ]; then
-          # rm /tmp/setup.sh
-      # fi
-      # wget http://project-downloads.drogon.net/gertboard/setup.sh
-      # chmod +x setup.sh
-      # sudo ./setup.sh
-      # #Enabling serial port in Arduino IDE
-      # crontab -l > file; echo '@reboot ln -sf /dev/ttyAMA0 /dev/ttyS0' >> file; crontab file
-      # rm file
-  	######################################################################
-  	source /home/pi/Dexter/lib/Dexter/script_tools/install_avrdude.sh
-  	create_avrdude_folder
-    install_avrdude
-    cd $ROBOT_DIR
-    echo "done with AVRDUDE "
-}
-
-call_for_reboot() {
-    if ! quiet_mode ; then
-        feedback " "
-        feedback "Please restart the Raspberry Pi for the changes to take effect"
-        feedback " "
-        feedback "Please restart to implement changes!"
-        feedback "  _____  ______  _____ _______       _____ _______ "
-        feedback " |  __ \|  ____|/ ____|__   __|/\   |  __ \__   __|"
-        feedback " | |__) | |__  | (___    | |  /  \  | |__) | | |   "
-        feedback " |  _  /|  __|  \___ \   | | / /\ \ |  _  /  | |   "
-        feedback " | | \ \| |____ ____) |  | |/ ____ \| | \ \  | |   "
-        feedback " |_|  \_\______|_____/   |_/_/    \_\_|  \_\ |_|   "
-        feedback " "
-        feedback "Please restart to implement changes!"
-        feedback "To Restart type sudo reboot"
-    fi
-}
-
 install_control_panel() {
     sudo cp "$ROBOT_DIR/Software/Python/control_panel/gopigo_control_panel.desktop" $PIHOME/Desktop
 }
 
 ############################################################################
 ############################################################################
-identify_cie
-identify_robot
+
 check_root_user
-display_welcome_msg
-check_internet
-
-echo "Installing GoPiGo software in ${ROBOT_DIR}"
-echo " "
-
 install_dependencies
 
-
-#Copy Software Servo
+# copy software servo
 sudo cp -R $ROBOT_DIR/Firmware/SoftwareServo/ /usr/share/arduino/libraries/
 
+# copy gopigo executable
+# the gopigo executable is for reporting data about the gopigo board
 sudo chmod +x gopigo
 sudo cp gopigo /usr/bin
 
-
-# remove old libraries, as Mutex is being searched in here instead of 
+# remove old libraries, as Mutex is being searched in here instead of
 # the proper place
 sudo pip uninstall gopigo -y
 sudo pip3 uninstall gopigo -y
@@ -251,12 +150,6 @@ python3 setup.py install --force
 install_DHT
 install_wiringpi
 install_spi_i2c
-# no longer installing avr for arduino
-# install_avr
 install_control_panel
 
-#sudo rm -r /tmp/di_update
-
 sudo chmod +x $ROBOT_DIR/Software/Scratch/GoPiGo_Scratch_Scripts/*.sh
-
-call_for_reboot

--- a/Setup/update_gopigo.sh
+++ b/Setup/update_gopigo.sh
@@ -187,7 +187,7 @@ remove_python_packages() {
   # but pip seems to know how to handle missing packages, which is okay
   while read path;
   do
-    if [[ ! -z "${path}" -a "${path}" != " " ]]; then
+    if [ ! -z "${path}" -a "${path}" != " " ]; then
       echo "Removing ${path} egg"
       sudo rm -f "${path}"
     fi

--- a/Setup/update_gopigo.sh
+++ b/Setup/update_gopigo.sh
@@ -213,7 +213,7 @@ install_python_pkgs_and_dependencies() {
   # installing dependencies if required
   if [[ $installdependencies = "true" ]]; then
     feedback "Installing GoPiGo dependencies. This might take a while.."
-    pushd $GOPIGO_DIR/Script > /dev/null
+    pushd $GOPIGO_DIR/Setup > /dev/null
     sudo bash ./install.sh
     popd > /dev/null
   fi

--- a/Setup/update_gopigo.sh
+++ b/Setup/update_gopigo.sh
@@ -1,9 +1,11 @@
 #! /bin/bash
+# This script updates the the code repos on Raspbian for Robots.
 
 ################################################
 ######## Parsing Command Line Arguments ########
 ################################################
 
+# definitions needed for standalone call
 PIHOME=/home/pi
 DEXTER=Dexter
 DEXTER_PATH=$PIHOME/$DEXTER
@@ -16,153 +18,160 @@ DEXTERSCRIPT=$DEXTER_PATH/lib/Dexter/script_tools
 REPO_PACKAGE=gopigo
 DHT_PACKAGE=Adafruit_DHT
 
-# whether to install the dependencies or not (avrdude, apt-get, wiringpi, and so on)
-installdependencies=true
-updaterepo=true
-install_pkg_scriptools=true
+# called way down below
+parse_cmdline_arguments() {
 
-# the following 3 options are mutually exclusive
-systemwide=true
-userlocal=false
-envlocal=false
-usepython3exec=true
+  # whether to install the dependencies or not (avrdude, apt-get, wiringpi, and so on)
+  installdependencies=true
+  updaterepo=true
+  install_pkg_scriptools=true
 
-# the following option tells which branch has to be used
-selectedbranch="master"
+  # the following 3 options are mutually exclusive
+  systemwide=true
+  userlocal=false
+  envlocal=false
+  usepython3exec=true
 
-declare -a optionslist=("--system-wide")
-# iterate through bash arguments
-for i; do
-  case "$i" in
-    --no-dependencies)
-      installdependencies=false
-      ;;
-    --no-update-aptget)
-      updaterepo=false
-      ;;
-    --bypass-pkg-scriptools)
-      install_pkg_scriptools=false
-      ;;
-    --user-local)
-      userlocal=true
-      systemwide=false
-      declare -a optionslist=("--user-local")
-      ;;
-    --env-local)
-      envlocal=true
-      systemwide=false
-      declare -a optionslist=("--env-local")
-      ;;
-    --system-wide)
-      ;;
-    develop|feature/*|hotfix/*|fix/*|DexterOS*|v*)
-      selectedbranch="$i"
-      ;;
-  esac
-done
+  # the following option tells which branch has to be used
+  selectedbranch="master"
 
-# show some feedback for the GoPiGo
-echo "  _____            _                                ";
-echo " |  __ \          | |                               ";
-echo " | |  | | _____  _| |_ ___ _ __                     ";
-echo " | |  | |/ _ \ \/ / __/ _ \ '__|                    ";
-echo " | |__| |  __/>  <| ||  __/ |                       ";
-echo " |_____/ \___/_/\_\\\__\___|_|          _            ";
-echo " |_   _|         | |         | |      (_)           ";
-echo "   | |  _ __   __| |_   _ ___| |_ _ __ _  ___  ___  ";
-echo "   | | | '_ \ / _\ | | | / __| __| '__| |/ _ \/ __| ";
-echo "  _| |_| | | | (_| | |_| \__ \ |_| |  | |  __/\__ \ ";
-echo " |_____|_| |_|\__,_|\__,_|___/\__|_|  |_|\___||___/ ";
-echo "                                                    ";
-echo "                                                    ";
-echo "  ______  _____   _____  _____  ______  _____ "
-echo " |  ____ |     | |_____]   |   |  ____ |     |"
-echo " |_____| |_____| |       __|__ |_____| |_____|"
-echo " "
+  declare -a optionslist=("--system-wide")
+  # iterate through bash arguments
+  for i; do
+    case "$i" in
+      --no-dependencies)
+        installdependencies=false
+        ;;
+      --no-update-aptget)
+        updaterepo=false
+        ;;
+      --bypass-pkg-scriptools)
+        install_pkg_scriptools=false
+        ;;
+      --user-local)
+        userlocal=true
+        systemwide=false
+        declare -a optionslist=("--user-local")
+        ;;
+      --env-local)
+        envlocal=true
+        systemwide=false
+        declare -a optionslist=("--env-local")
+        ;;
+      --system-wide)
+        ;;
+      develop|feature/*|hotfix/*|fix/*|DexterOS*|v*)
+        selectedbranch="$i"
+        ;;
+    esac
+  done
 
-# show some feedback on the console
-if [ -f $DEXTERSCRIPT/functions_library.sh ]; then
+  # show some feedback on the console
+  if [ -f $DEXTERSCRIPT/functions_library.sh ]; then
+    source $DEXTERSCRIPT/functions_library.sh
+    # show some feedback for the GoPiGo
+    if [ ! quiet_mode ]; then
+      echo "  _____            _                                ";
+      echo " |  __ \          | |                               ";
+      echo " | |  | | _____  _| |_ ___ _ __                     ";
+      echo " | |  | |/ _ \ \/ / __/ _ \ '__|                    ";
+      echo " | |__| |  __/>  <| ||  __/ |                       ";
+      echo " |_____/ \___/_/\_\\\__\___|_|          _            ";
+      echo " |_   _|         | |         | |      (_)           ";
+      echo "   | |  _ __   __| |_   _ ___| |_ _ __ _  ___  ___  ";
+      echo "   | | | '_ \ / _\ | | | / __| __| '__| |/ _ \/ __| ";
+      echo "  _| |_| | | | (_| | |_| \__ \ |_| |  | |  __/\__ \ ";
+      echo " |_____|_| |_|\__,_|\__,_|___/\__|_|  |_|\___||___/ ";
+      echo "                                                    ";
+      echo "                                                    ";
+      echo "  ______  _____   _____  _____  ______  _____ "
+      echo " |  ____ |     | |_____]   |   |  ____ |     |"
+      echo " |_____| |_____| |       __|__ |_____| |_____|"
+      echo " "
+    fi
+    feedback "Welcome to GoPiGo Installer."
+  else
+    echo "Welcome to GoPiGo Installer."
+  fi
+  echo "Updating GoPiGo for $selectedbranch branch with the following options:"
+  ([[ $installdependencies = "true" ]] && echo "  --no-dependencies=false") || echo "  --no-dependencies=true"
+  ([[ $updaterepo = "true" ]] && echo "  --no-update-aptget=false") || echo "  --no-update-aptget=true"
+  ([[ $install_pkg_scriptools = "true" ]] && echo "  --bypass-pkg-scriptools=false") || echo "  --bypass-pkg-scriptools=true"
+  echo "  --user-local=$userlocal"
+  echo "  --env-local=$envlocal"
+  echo "  --system-wide=$systemwide"
+
+  # in case the following packages are not installed and `--no-dependencies` option has been used
+  if [[ $installdependencies = "false" ]]; then
+    command -v git >/dev/null 2>&1 || { echo "This script requires \"git\" but it's not installed. Don't use --no-dependencies option. Aborting." >&2; exit 1; }
+    command -v python >/dev/null 2>&1 || { echo "Executable \"python\" couldn't be found. Don't use --no-dependencies option. Aborting." >&2; exit 2; }
+    command -v python3 >/dev/null 2>&1 || { echo "Executable \"python3\" couldn't be found. Don't use --no-dependencies option. Aborting." >&2; exit 3; }
+    command -v pip >/dev/null 2>&1 || { echo "Executable \"pip\" couldn't be found. Don't use --no-dependencies option. Aborting." >&2; exit 4; }
+    command -v pip3 >/dev/null 2>&1 || { echo "Executable \"pip3\" couldn't be found. Don't use --no-dependencies option. Aborting." >&2; exit 5; }
+  fi
+
+  # create rest of list of arguments for script_tools call
+  optionslist+=("$selectedbranch")
+  [[ $usepython3exec = "true" ]] && optionslist+=("--use-python3-exe-too")
+  [[ $updaterepo = "true" ]] && optionslist+=("--update-aptget")
+  [[ $installdependencies = "true" ]] && optionslist+=("--install-deb-deps")
+  [[ $install_pkg_scriptools = "true" ]] && optionslist+=("--install-python-package")
+
+  echo "Options used for script_tools script: \"${optionslist[@]}\""
+}
+
+################################################
+######## Cloning GrovePi & Script_Tools  #######
+################################################
+
+# called way down below
+clone_gopigo_and_scriptools() {
+  # update script_tools first
+  curl --silent -kL dexterindustries.com/update_tools > $PIHOME/.tmp_script_tools.sh
+  echo "Installing script_tools. This might take a while.."
+  bash $PIHOME/.tmp_script_tools.sh ${optionslist[@]} > /dev/null
+  ret_val=$?
+  rm $PIHOME/.tmp_script_tools.sh
+  if [[ $ret_val -ne 0 ]]; then
+    echo "script_tools failed installing with exit code $ret_val. Aborting."
+    exit 6
+  fi
+  echo "Done installing script_tools"
+
+  # needs to be sourced from here when we call this as a standalone
   source $DEXTERSCRIPT/functions_library.sh
-  feedback "Welcome to GoPiGo Installer."
-else
-  echo "Welcome to GoPiGo Installer."
-fi
-echo "Updating GoPiGo for $selectedbranch branch with the following options:"
-([[ $installdependencies = "true" ]] && echo "  --no-dependencies=false") || echo "  --no-dependencies=true"
-([[ $updaterepo = "true" ]] && echo "  --no-update-aptget=false") || echo "  --no-update-aptget=true"
-([[ $install_pkg_scriptools = "true" ]] && echo "  --bypass-pkg-scriptools=false") || echo "  --bypass-pkg-scriptools=true"
-echo "  --user-local=$userlocal"
-echo "  --env-local=$envlocal"
-echo "  --system-wide=$systemwide"
 
-# in case the following packages are not installed and `--no-dependencies` option has been used
-if [[ $installdependencies = "false" ]]; then
-  command -v git >/dev/null 2>&1 || { echo "I require \"git\" but it's not installed. Aborting." >&2; exit 1; }
-  command -v python >/dev/null 2>&1 || { echo "Executable \"python\" couldn't be found. Don't use --no-dependencies option. Aborting." >&2; exit 2; }
-  command -v python3 >/dev/null 2>&1 || { echo "Executable \"python3\" couldn't be found. Don't use --no-dependencies option. Aborting." >&2; exit 3; }
-  command -v pip >/dev/null 2>&1 || { echo "Executable \"pip\" couldn't be found. Don't use --no-dependencies option. Aborting." >&2; exit 4; }
-  command -v pip3 >/dev/null 2>&1 || { echo "Executable \"pip3\" couldn't be found. Don't use --no-dependencies option. Aborting." >&2; exit 5; }
-fi
+  # create folders recursively if they don't exist already
+  # we use sudo for creating the dir(s) because on older versions of R4R
+  # the sudo command is used, and hence we need to be sure we have write permissions.
+  sudo mkdir -p $DEXTER_PATH
+  # still only available for the pi user
+  # shortly after this, we'll make it work for any user
+  sudo chown pi:pi -R $DEXTER_PATH
+  cd $DEXTER_PATH
 
-# create rest of list of arguments for script_tools call
-optionslist+=("$selectedbranch")
-[[ $usepython3exec = "true" ]] && optionslist+=("--use-python3-exe-too")
-[[ $updaterepo = "true" ]] && optionslist+=("--update-aptget")
-[[ $installdependencies = "true" ]] && optionslist+=("--install-deb-deps")
-[[ $install_pkg_scriptools = "true" ]] && optionslist+=("--install-python-package")
-
-echo "Options used for script_tools script: \"${optionslist[@]}\""
-
-################################################
-######## Cloning GoPiGo & Script_Tools  ########
-################################################
-
-# update script_tools first
-curl --silent -kL dexterindustries.com/update_tools > $PIHOME/.tmp_script_tools.sh
-echo "Installing script_tools. This might take a while.."
-bash $PIHOME/.tmp_script_tools.sh ${optionslist[@]} > /dev/null
-ret_val=$?
-rm $PIHOME/.tmp_script_tools.sh
-if [[ $ret_val -ne 0 ]]; then
-  echo "script_tools failed installing with exit code $ret_val. Aborting."
-  exit 6
-fi
-
-# HAVE TO UNCOMMENT ONCE check_internet makes it to script_tools
-# check if there's internet access,
-# otherwise straight out exit the script
-# check_internet
-
-# needs to be sourced from here when we call this as a standalone
-source $DEXTERSCRIPT/functions_library.sh
-
-# create folders recursively if they don't exist already
-# we use sudo for creating the dir(s) because on older versions of R4R
-# the sudo command is used, and hence we need to be sure we have write permissions.
-sudo mkdir -p $DEXTER_PATH
-# still only available for the pi user
-# shortly after this, we'll make it work for any user
-sudo chown pi:pi -R $DEXTER_PATH
-cd $DEXTER_PATH
-
-# it's simpler and more reliable (for now) to just delete the repo and clone a new one
-# otherwise, we'd have to deal with all the intricacies of git
-sudo rm -rf $GOPIGO_DIR
-git clone --quiet --depth=1 -b $selectedbranch https://github.com/DexterInd/GoPiGo.git
-cd $GOPIGO_DIR
+  # it's simpler and more reliable (for now) to just delete the repo and clone a new one
+  # otherwise, we'd have to deal with all the intricacies of git
+  sudo rm -rf $GOPIGO_DIR
+  git clone --quiet --depth=1 -b $selectedbranch https://github.com/DexterInd/GrovePi.git
+  cd $GOPIGO_DIR
+}
 
 ################################################
 ######## Install Python Packages & Deps ########
 ################################################
 
-echo "Installing GoPiGo dependencies and package. This might take a while.."
+# called by <<install_python_pkgs_and_dependencies>>
+install_python_packages() {
+  [[ $systemwide = "true" ]] && sudo python setup.py install \
+              && [[ $usepython3exec = "true" ]] && sudo python3 setup.py install
+  [[ $userlocal = "true" ]] && python setup.py install --user \
+              && [[ $usepython3exec = "true" ]] && python3 setup.py install --user
+  [[ $envlocal = "true" ]] && python setup.py install \
+              && [[ $usepython3exec = "true" ]] && python3 setup.py install
+}
 
-# installing dependencies
-pushd $GOPIGO_DIR/Setup > /dev/null
-sudo chmod +x install.sh
-[[ $installdependencies = "true" ]] && sudo bash ./install.sh
-popd > /dev/null
-
+# called by <<install_python_pkgs_and_dependencies>>
 remove_python_packages() {
   # the 1st and only argument
   # takes the name of the package that needs to removed
@@ -199,28 +208,32 @@ remove_python_packages() {
   done < $PIHOME/.pypaths
 }
 
-install_python_packages() {
-  [[ $systemwide = "true" ]] && sudo python setup.py install \
-              && [[ $usepython3exec = "true" ]] && sudo python3 setup.py install
-  [[ $userlocal = "true" ]] && python setup.py install --user \
-              && [[ $usepython3exec = "true" ]] && python3 setup.py install --user
-  [[ $envlocal = "true" ]] && python setup.py install \
-              && [[ $usepython3exec = "true" ]] && python3 setup.py install
+# called way down bellow
+install_python_pkgs_and_dependencies() {
+  # installing dependencies if required
+  if [[ $installdependencies = "true" ]]; then
+    feedback "Installing GoPiGo dependencies. This might take a while.."
+    pushd $GROVEPI_DIR/Script > /dev/null
+    sudo bash ./install.sh
+    popd > /dev/null
+  fi
+
+  # feedback "Removing \"$REPO_PACKAGE\" and \"$DHT_PACKAGE\" to make space for new ones"
+  feedback "Removing \"$REPO_PACKAGE\" to make space for the new one"
+  remove_python_packages "$REPO_PACKAGE"
+  # remove_python_packages "$DHT_PACKAGE"
+
+  # installing the package itself
+  pushd $GOPIGO_DIR/Software/Python > /dev/null
+  install_python_packages
+  popd > /dev/null
 }
 
-# feedback "Removing \"$REPO_PACKAGE\" and \"$DHT_PACKAGE\" to make space for new ones"
-feedback "Removing \"$REPO_PACKAGE\" to make space for the new one"
-remove_python_packages "$REPO_PACKAGE"
-# remove_python_packages "$DHT_PACKAGE"
+################################################
+######## Aggregating all function calls ########
+################################################
 
-# installing the package itself
-pushd $GOPIGO_DIR/Software/Python > /dev/null
-install_python_packages
-popd > /dev/null
-
-# installing the DHT package
-# pushd $GOPIGO_DIR/Software/Python/sensor_examples/dht/Adafruit_Python_DHT > /dev/null
-# install_python_packages
-# popd > /dev/null
-
+parse_cmdline_arguments "$@"
+clone_gopigo_and_scriptools
+install_python_pkgs_and_dependencies
 exit 0

--- a/Setup/update_gopigo.sh
+++ b/Setup/update_gopigo.sh
@@ -156,7 +156,7 @@ pushd $GOPIGO_DIR/Software/Python > /dev/null
 install_python_packages
 popd > /dev/null
 
-# installing the DHT packages
+# installing the DHT package
 pushd $ROBOT_DIR/Software/Python/sensor_examples/dht/Adafruit_Python_DHT > /dev/null
 install_python_packages
 popd > /dev/null

--- a/Setup/update_gopigo.sh
+++ b/Setup/update_gopigo.sh
@@ -168,18 +168,18 @@ remove_python_packages() {
   # does this for both root and the current user because packages can be either system-wide or local
   # later on the strings used with the python command can be put in just one string that gets used repeatedly
   python -c "import pkgutil; import os; \
-              eggs_loader = pkgutil.find_loader('$REPO_PACKAGE'); found = eggs_loader is not None; \
-              output = os.path.dirname(os.path.realpath(eggs_loader.get_filename('$REPO_PACKAGE'))) if found else ''; print(output);" >> $PIHOME/.pypaths
+              eggs_loader = pkgutil.find_loader('$1'); found = eggs_loader is not None; \
+              output = os.path.dirname(os.path.realpath(eggs_loader.get_filename('$1'))) if found else ''; print(output);" >> $PIHOME/.pypaths
   sudo python -c "import pkgutil; import os; \
-              eggs_loader = pkgutil.find_loader('$REPO_PACKAGE'); found = eggs_loader is not None; \
-              output = os.path.dirname(os.path.realpath(eggs_loader.get_filename('$REPO_PACKAGE'))) if found else ''; print(output);" >> $PIHOME/.pypaths
+              eggs_loader = pkgutil.find_loader('$1'); found = eggs_loader is not None; \
+              output = os.path.dirname(os.path.realpath(eggs_loader.get_filename('$1'))) if found else ''; print(output);" >> $PIHOME/.pypaths
   if [[ $usepython3exec = "true" ]]; then
     python3 -c "import pkgutil; import os; \
-                eggs_loader = pkgutil.find_loader('$REPO_PACKAGE'); found = eggs_loader is not None; \
-                output = os.path.dirname(os.path.realpath(eggs_loader.get_filename('$REPO_PACKAGE'))) if found else ''; print(output);" >> $PIHOME/.pypaths
+                eggs_loader = pkgutil.find_loader('$1'); found = eggs_loader is not None; \
+                output = os.path.dirname(os.path.realpath(eggs_loader.get_filename('$1'))) if found else ''; print(output);" >> $PIHOME/.pypaths
     sudo python3 -c "import pkgutil; import os; \
-                eggs_loader = pkgutil.find_loader('$REPO_PACKAGE'); found = eggs_loader is not None; \
-                output = os.path.dirname(os.path.realpath(eggs_loader.get_filename('$REPO_PACKAGE'))) if found else ''; print(output);" >> $PIHOME/.pypaths
+                eggs_loader = pkgutil.find_loader('$1'); found = eggs_loader is not None; \
+                output = os.path.dirname(os.path.realpath(eggs_loader.get_filename('$1'))) if found else ''; print(output);" >> $PIHOME/.pypaths
   fi
 
   # removing eggs for $1 python package
@@ -203,9 +203,10 @@ install_python_packages() {
               && [[ $usepython3exec = "true" ]] && python3 setup.py install
 }
 
-feedback "Removing \"$REPO_PACKAGE\" and \"$DHT_PACKAGE\" to make space for new ones"
+# feedback "Removing \"$REPO_PACKAGE\" and \"$DHT_PACKAGE\" to make space for new ones"
+feedback "Removing \"$REPO_PACKAGE\" to make space for the new one"
 remove_python_packages "$REPO_PACKAGE"
-remove_python_packages "$DHT_PACKAGE"
+# remove_python_packages "$DHT_PACKAGE"
 
 # installing the package itself
 pushd $GOPIGO_DIR/Software/Python > /dev/null
@@ -213,8 +214,8 @@ install_python_packages
 popd > /dev/null
 
 # installing the DHT package
-pushd $GOPIGO_DIR/Software/Python/sensor_examples/dht/Adafruit_Python_DHT > /dev/null
-install_python_packages
-popd > /dev/null
+# pushd $GOPIGO_DIR/Software/Python/sensor_examples/dht/Adafruit_Python_DHT > /dev/null
+# install_python_packages
+# popd > /dev/null
 
 exit 0

--- a/Setup/update_gopigo.sh
+++ b/Setup/update_gopigo.sh
@@ -103,11 +103,11 @@ parse_cmdline_arguments() {
 
   # in case the following packages are not installed and `--no-dependencies` option has been used
   if [[ $installdependencies = "false" ]]; then
-    command -v git >/dev/null 2>&1 || { echo "This script requires \"git\" but it's not installed. Don't use --no-dependencies option. Aborting." >&2; exit 1; }
-    command -v python >/dev/null 2>&1 || { echo "Executable \"python\" couldn't be found. Don't use --no-dependencies option. Aborting." >&2; exit 2; }
-    command -v python3 >/dev/null 2>&1 || { echo "Executable \"python3\" couldn't be found. Don't use --no-dependencies option. Aborting." >&2; exit 3; }
-    command -v pip >/dev/null 2>&1 || { echo "Executable \"pip\" couldn't be found. Don't use --no-dependencies option. Aborting." >&2; exit 4; }
-    command -v pip3 >/dev/null 2>&1 || { echo "Executable \"pip3\" couldn't be found. Don't use --no-dependencies option. Aborting." >&2; exit 5; }
+    command -v git >/dev/null 2>&1 || { echo "This script requires \"git\" but it's not installed. Don't use --no-dependencies option. Exiting." >&2; exit 1; }
+    command -v python >/dev/null 2>&1 || { echo "Executable \"python\" couldn't be found. Don't use --no-dependencies option. Exiting." >&2; exit 2; }
+    command -v python3 >/dev/null 2>&1 || { echo "Executable \"python3\" couldn't be found. Don't use --no-dependencies option. Exiting." >&2; exit 3; }
+    command -v pip >/dev/null 2>&1 || { echo "Executable \"pip\" couldn't be found. Don't use --no-dependencies option. Exiting." >&2; exit 4; }
+    command -v pip3 >/dev/null 2>&1 || { echo "Executable \"pip3\" couldn't be found. Don't use --no-dependencies option. Exiting." >&2; exit 5; }
   fi
 
   # create rest of list of arguments for script_tools call
@@ -133,7 +133,7 @@ clone_gopigo_and_scriptools() {
   ret_val=$?
   rm $PIHOME/.tmp_script_tools.sh
   if [[ $ret_val -ne 0 ]]; then
-    echo "script_tools failed installing with exit code $ret_val. Aborting."
+    echo "script_tools failed installing with exit code $ret_val. Exiting."
     exit 6
   fi
   echo "Done installing script_tools"

--- a/Setup/update_gopigo.sh
+++ b/Setup/update_gopigo.sh
@@ -27,3 +27,154 @@ feedback "--> UPDATING LIBRARIES"
 feedback "------------------"
 bash ./install.sh
 popd > /dev/null
+
+#####################################################
+
+# This script updates the the code repos on Raspbian for Robots.
+
+# definitions needed for standalone call
+PIHOME=/home/pi
+DEXTER=Dexter
+DEXTER_PATH=$PIHOME/$DEXTER
+RASPBIAN=$PIHOME/di_update/Raspbian_For_Robots
+GROVEPI_DIR=$DEXTER_PATH/GrovePi
+DEXTERSCRIPT=$DEXTER_PATH/lib/Dexter/script_tools
+
+# whether to install the dependencies or not (avrdude, apt-get, wiringpi, and so on)
+installdependencies=true
+updaterepo=true
+install_pkg_scriptools=true
+
+# the following 3 options are mutually exclusive
+systemwide=true
+userlocal=false
+envlocal=false
+usepython3exec=true
+
+# the following option tells which branch has to be used
+selectedbranch="master"
+
+declare -a optionslist=("--system-wide")
+# iterate through bash arguments
+for i; do
+  case "$i" in
+    --no-dependencies)
+      installdependencies=false
+      ;;
+    --no-update-aptget)
+      updaterepo=false
+      ;;
+    --bypass-pkg-scriptools)
+      install_pkg_scriptools=false
+      ;;
+    --user-local)
+      userlocal=true
+      systemwide=false
+      declare -a optionslist=("--user-local")
+      ;;
+    --env-local)
+      envlocal=true
+      systemwide=false
+      declare -a optionslist=("--env-local")
+      ;;
+    --system-wide)
+      ;;
+    develop|feature/*|hotfix/*|fix/*|DexterOS*|v*)
+      selectedbranch="$i"
+      ;;
+  esac
+done
+
+# show some feedback for the GrovePi
+echo "  _____            _                                ";
+echo " |  __ \          | |                               ";
+echo " | |  | | _____  _| |_ ___ _ __                     ";
+echo " | |  | |/ _ \ \/ / __/ _ \ '__|                    ";
+echo " | |__| |  __/>  <| ||  __/ |                       ";
+echo " |_____/ \___/_/\_\\\__\___|_|          _            ";
+echo " |_   _|         | |         | |      (_)           ";
+echo "   | |  _ __   __| |_   _ ___| |_ _ __ _  ___  ___  ";
+echo "   | | | '_ \ / _\ | | | / __| __| '__| |/ _ \/ __| ";
+echo "  _| |_| | | | (_| | |_| \__ \ |_| |  | |  __/\__ \ ";
+echo " |_____|_| |_|\__,_|\__,_|___/\__|_|  |_|\___||___/ ";
+echo "                                                    ";
+echo "                                                    ";
+echo "  ______  _____   _____  _____  ______  _____ "
+echo " |  ____ |     | |_____]   |   |  ____ |     |"
+echo " |_____| |_____| |       __|__ |_____| |_____|"
+echo " "
+
+# show some feedback on the console
+if [ -f $DEXTERSCRIPT/functions_library.sh ]; then
+  source $DEXTERSCRIPT/functions_library.sh
+  feedback "Welcome to GrovePi Installer."
+else
+  echo "Welcome to GrovePi Installer."
+fi
+echo "Updating GrovePi for $selectedbranch branch with the following options:"
+([[ $installdependencies = "true" ]] && echo "  --no-dependencies=false") || echo "  --no-dependencies=true"
+([[ $updaterepo = "true" ]] && echo "  --no-update-aptget=false") || echo "  --no-update-aptget=true"
+([[ $install_pkg_scriptools = "true" ]] && echo "  --bypass-pkg-scriptools=false") || echo "  --bypass-pkg-scriptools=true"
+echo "  --user-local=$userlocal"
+echo "  --env-local=$envlocal"
+echo "  --system-wide=$systemwide"
+
+# in case the following packages are not installed and `--no-dependencies` option has been used
+if [[ $installdependencies = "false" ]]; then
+  command -v git >/dev/null 2>&1 || { echo "I require git but it's not installed. Don't use --no-dependencies option. Aborting." >&2; exit 1; }
+  command -v python >/dev/null 2>&1 || { echo "Executable \"python\" couldn't be found. Don't use --no-dependencies option. Aborting." >&2; exit 2; }
+  command -v python3 >/dev/null 2>&1 || { echo "Executable \"python3\" couldn't be found. Don't use --no-dependencies option. Aborting." >&2; exit 3; }
+  command -v pip >/dev/null 2>&1 || { echo "Executable \"pip\" couldn't be found. Don't use --no-dependencies option. Aborting." >&2; exit 4; }
+  command -v pip3 >/dev/null 2>&1 || { echo "Executable \"pip3\" couldn't be found. Don't use --no-dependencies option. Aborting." >&2; exit 5; }
+fi
+
+# create rest of list of arguments for script_tools call
+optionslist+=("$selectedbranch")
+[[ $usepython3exec = "true" ]] && optionslist+=("--use-python3-exe-too")
+[[ $updaterepo = "true" ]] && optionslist+=("--update-aptget")
+[[ $installdependencies = "true" ]] && optionslist+=("--install-deb-deps")
+[[ $install_pkg_scriptools = "true" ]] && optionslist+=("--install-python-package")
+
+echo "Options used for script_tools script: \"${optionslist[@]}\""
+
+# update script_tools first
+curl --silent -kL dexterindustries.com/update_tools > $PIHOME/tmp_script_tools.sh
+echo "Installing script_tools. This might take a while.."
+bash $PIHOME/tmp_script_tools.sh ${optionslist[@]} > /dev/null
+rm $PIHOME/tmp_script_tools.sh
+
+# HAVE TO UNCOMMENT ONCE check_internet makes it to script_tools
+# check if there's internet access,
+# otherwise straight out exit the script
+# check_internet
+
+# needs to be sourced from here when we call this as a standalone
+source /home/pi/$DEXTER/lib/$DEXTER/script_tools/functions_library.sh
+
+# create folders recursively if they don't exist already
+mkdir -p $DEXTER_PATH
+cd $DEXTER_PATH
+
+# it's simpler and more reliable (for now) to just delete the repo and clone a new one
+# otherwise, we'd have to deal with all the intricacies of git
+sudo rm -rf $GROVEPI_DIR
+git clone --quiet --depth=1 -b $selectedbranch https://github.com/DexterInd/GrovePi.git
+cd $GROVEPI_DIR
+
+echo "Installing GrovePi dependencies and package. This might take a while.."
+
+# installing dependencies
+pushd $GROVEPI_DIR/Script > /dev/null
+sudo chmod +x install.sh
+[[ $installdependencies = "true" ]] && sudo bash ./install.sh
+popd > /dev/null
+
+# installing the package itself
+pushd $GROVEPI_DIR/Software/Python > /dev/null
+[[ $systemwide = "true" ]] && sudo python setup.py install --force \
+            && [[ $usepython3exec = "true" ]] && sudo python3 setup.py install --force
+[[ $userlocal = "true" ]] && python setup.py install --force --user \
+            && [[ $usepython3exec = "true" ]] && python3 setup.py install --force --user
+[[ $envlocal = "true" ]] && python setup.py install --force \
+            && [[ $usepython3exec = "true" ]] && python3 setup.py install --force
+popd > /dev/null

--- a/Setup/update_gopigo.sh
+++ b/Setup/update_gopigo.sh
@@ -18,6 +18,15 @@ DEXTERSCRIPT=$DEXTER_PATH/lib/Dexter/script_tools
 REPO_PACKAGE=gopigo
 DHT_PACKAGE=Adafruit_DHT
 
+# called way down bellow
+check_if_run_with_pi() {
+  ## if not running with the pi user then exit
+  if [ $(id -ur) -ne $(id -ur pi) ]; then
+    echo "GoPiGo3 installer script must be run with \"pi\" user. Exiting."
+    exit 7
+  fi
+}
+
 # called way down below
 parse_cmdline_arguments() {
 
@@ -233,6 +242,7 @@ install_python_pkgs_and_dependencies() {
 ######## Aggregating all function calls ########
 ################################################
 
+check_if_run_with_pi
 parse_cmdline_arguments "$@"
 clone_gopigo_and_scriptools
 install_python_pkgs_and_dependencies

--- a/Setup/update_gopigo.sh
+++ b/Setup/update_gopigo.sh
@@ -125,10 +125,10 @@ cd $DEXTER_PATH
 # it's simpler and more reliable (for now) to just delete the repo and clone a new one
 # otherwise, we'd have to deal with all the intricacies of git
 sudo rm -rf $GOPIGO_DIR
-git clone --quiet --depth=1 -b $selectedbranch https://github.com/DexterInd/GrovePi.git
+git clone --quiet --depth=1 -b $selectedbranch https://github.com/DexterInd/GoPiGo.git
 cd $GOPIGO_DIR
 
-echo "Installing GrovePi dependencies and package. This might take a while.."
+echo "Installing GoPiGo dependencies and package. This might take a while.."
 
 # installing dependencies
 pushd $GOPIGO_DIR/Script > /dev/null
@@ -136,12 +136,27 @@ sudo chmod +x install.sh
 [[ $installdependencies = "true" ]] && sudo bash ./install.sh
 popd > /dev/null
 
+install_python_packages() {
+  [[ $systemwide = "true" ]] && sudo python setup.py install --force \
+              && [[ $usepython3exec = "true" ]] && sudo python3 setup.py install --force
+  [[ $userlocal = "true" ]] && python setup.py install --force --user \
+              && [[ $usepython3exec = "true" ]] && python3 setup.py install --force --user
+  [[ $envlocal = "true" ]] && python setup.py install --force \
+              && [[ $usepython3exec = "true" ]] && python3 setup.py install --force
+}
+
+# remove old libraries, as Mutex is being searched in here instead of
+# the proper place - this will only work with system-wide packages,
+# which was the original way of installing packages and still is
+sudo pip uninstall gopigo -y > /dev/null
+sudo pip3 uninstall gopigo -y > /dev/null
+
 # installing the package itself
 pushd $GOPIGO_DIR/Software/Python > /dev/null
-[[ $systemwide = "true" ]] && sudo python setup.py install --force \
-            && [[ $usepython3exec = "true" ]] && sudo python3 setup.py install --force
-[[ $userlocal = "true" ]] && python setup.py install --force --user \
-            && [[ $usepython3exec = "true" ]] && python3 setup.py install --force --user
-[[ $envlocal = "true" ]] && python setup.py install --force \
-            && [[ $usepython3exec = "true" ]] && python3 setup.py install --force
+install_python_packages
+popd > /dev/null
+
+# installing the DHT packages
+pushd $ROBOT_DIR/Software/Python/sensor_examples/dht/Adafruit_Python_DHT > /dev/null
+install_python_packages
 popd > /dev/null

--- a/Setup/update_gopigo.sh
+++ b/Setup/update_gopigo.sh
@@ -22,7 +22,7 @@ DHT_PACKAGE=Adafruit_DHT
 check_if_run_with_pi() {
   ## if not running with the pi user then exit
   if [ $(id -ur) -ne $(id -ur pi) ]; then
-    echo "GoPiGo3 installer script must be run with \"pi\" user. Exiting."
+    echo "GoPiGo installer script must be run with \"pi\" user. Exiting."
     exit 7
   fi
 }

--- a/Setup/update_gopigo.sh
+++ b/Setup/update_gopigo.sh
@@ -121,7 +121,7 @@ parse_cmdline_arguments() {
 }
 
 ################################################
-######## Cloning GrovePi & Script_Tools  #######
+######## Cloning GoPiGo & Script_Tools  ########
 ################################################
 
 # called way down below
@@ -153,7 +153,7 @@ clone_gopigo_and_scriptools() {
   # it's simpler and more reliable (for now) to just delete the repo and clone a new one
   # otherwise, we'd have to deal with all the intricacies of git
   sudo rm -rf $GOPIGO_DIR
-  git clone --quiet --depth=1 -b $selectedbranch https://github.com/DexterInd/GrovePi.git
+  git clone --quiet --depth=1 -b $selectedbranch https://github.com/DexterInd/GoPiGo.git
   cd $GOPIGO_DIR
 }
 
@@ -213,7 +213,7 @@ install_python_pkgs_and_dependencies() {
   # installing dependencies if required
   if [[ $installdependencies = "true" ]]; then
     feedback "Installing GoPiGo dependencies. This might take a while.."
-    pushd $GROVEPI_DIR/Script > /dev/null
+    pushd $GOPIGO_DIR/Script > /dev/null
     sudo bash ./install.sh
     popd > /dev/null
   fi

--- a/Setup/update_gopigo.sh
+++ b/Setup/update_gopigo.sh
@@ -86,9 +86,9 @@ echo "  --user-local=$userlocal"
 echo "  --env-local=$envlocal"
 echo "  --system-wide=$systemwide"
 
-command -v git >/dev/null 2>&1 || { echo "I require \"git\" but it's not installed. Aborting." >&2; exit 1; }
 # in case the following packages are not installed and `--no-dependencies` option has been used
 if [[ $installdependencies = "false" ]]; then
+  command -v git >/dev/null 2>&1 || { echo "I require \"git\" but it's not installed. Aborting." >&2; exit 1; }
   command -v python >/dev/null 2>&1 || { echo "Executable \"python\" couldn't be found. Don't use --no-dependencies option. Aborting." >&2; exit 2; }
   command -v python3 >/dev/null 2>&1 || { echo "Executable \"python3\" couldn't be found. Don't use --no-dependencies option. Aborting." >&2; exit 3; }
   command -v pip >/dev/null 2>&1 || { echo "Executable \"pip\" couldn't be found. Don't use --no-dependencies option. Aborting." >&2; exit 4; }
@@ -131,7 +131,7 @@ cd $GOPIGO_DIR
 echo "Installing GoPiGo dependencies and package. This might take a while.."
 
 # installing dependencies
-pushd $GOPIGO_DIR/Script > /dev/null
+pushd $GOPIGO_DIR/Setup > /dev/null
 sudo chmod +x install.sh
 [[ $installdependencies = "true" ]] && sudo bash ./install.sh
 popd > /dev/null
@@ -157,6 +157,6 @@ install_python_packages
 popd > /dev/null
 
 # installing the DHT package
-pushd $ROBOT_DIR/Software/Python/sensor_examples/dht/Adafruit_Python_DHT > /dev/null
+pushd $GOPIGO_DIR/Software/Python/sensor_examples/dht/Adafruit_Python_DHT > /dev/null
 install_python_packages
 popd > /dev/null

--- a/Setup/update_gopigo.sh
+++ b/Setup/update_gopigo.sh
@@ -86,9 +86,9 @@ echo "  --user-local=$userlocal"
 echo "  --env-local=$envlocal"
 echo "  --system-wide=$systemwide"
 
+command -v git >/dev/null 2>&1 || { echo "I require \"git\" but it's not installed. Aborting." >&2; exit 1; }
 # in case the following packages are not installed and `--no-dependencies` option has been used
 if [[ $installdependencies = "false" ]]; then
-  command -v git >/dev/null 2>&1 || { echo "I require git but it's not installed. Don't use --no-dependencies option. Aborting." >&2; exit 1; }
   command -v python >/dev/null 2>&1 || { echo "Executable \"python\" couldn't be found. Don't use --no-dependencies option. Aborting." >&2; exit 2; }
   command -v python3 >/dev/null 2>&1 || { echo "Executable \"python3\" couldn't be found. Don't use --no-dependencies option. Aborting." >&2; exit 3; }
   command -v pip >/dev/null 2>&1 || { echo "Executable \"pip\" couldn't be found. Don't use --no-dependencies option. Aborting." >&2; exit 4; }
@@ -116,7 +116,7 @@ rm $PIHOME/tmp_script_tools.sh
 # check_internet
 
 # needs to be sourced from here when we call this as a standalone
-source /home/pi/$DEXTER/lib/$DEXTER/script_tools/functions_library.sh
+source $DEXTERSCRIPT/functions_library.sh
 
 # create folders recursively if they don't exist already
 mkdir -p $DEXTER_PATH

--- a/Setup/update_gopigo.sh
+++ b/Setup/update_gopigo.sh
@@ -108,7 +108,12 @@ echo "Options used for script_tools script: \"${optionslist[@]}\""
 curl --silent -kL dexterindustries.com/update_tools > $PIHOME/tmp_script_tools.sh
 echo "Installing script_tools. This might take a while.."
 bash $PIHOME/tmp_script_tools.sh ${optionslist[@]} > /dev/null
+ret_val=$?
 rm $PIHOME/tmp_script_tools.sh
+if [[ $ret_val -ne 0 ]]; then
+  echo "script_tools failed installing with exit code $ret_val. Aborting."
+  exit 6
+fi
 
 # HAVE TO UNCOMMENT ONCE check_internet makes it to script_tools
 # check if there's internet access,
@@ -160,3 +165,5 @@ popd > /dev/null
 pushd $GOPIGO_DIR/Software/Python/sensor_examples/dht/Adafruit_Python_DHT > /dev/null
 install_python_packages
 popd > /dev/null
+
+exit 0

--- a/Setup/update_gopigo.sh
+++ b/Setup/update_gopigo.sh
@@ -44,7 +44,7 @@ parse_cmdline_arguments() {
   # the following option tells which branch has to be used
   selectedbranch="master"
 
-  declare -a optionslist=("--system-wide")
+  declare -ga optionslist=("--system-wide")
   # iterate through bash arguments
   for i; do
     case "$i" in
@@ -60,12 +60,12 @@ parse_cmdline_arguments() {
       --user-local)
         userlocal=true
         systemwide=false
-        declare -a optionslist=("--user-local")
+        declare -ga optionslist=("--user-local")
         ;;
       --env-local)
         envlocal=true
         systemwide=false
-        declare -a optionslist=("--env-local")
+        declare -ga optionslist=("--env-local")
         ;;
       --system-wide)
         ;;

--- a/Setup/update_gopigo.sh
+++ b/Setup/update_gopigo.sh
@@ -1,43 +1,10 @@
+#! /bin/bash
+
 PIHOME=/home/pi
 DEXTER=Dexter
 DEXTER_PATH=$PIHOME/$DEXTER
 RASPBIAN=$PIHOME/di_update/Raspbian_For_Robots
-curl --silent https://raw.githubusercontent.com/DexterInd/script_tools/master/install_script_tools.sh | bash
-
-# needs to be sourced from here when we call this as a standalone
-source $PIHOME/$DEXTER/lib/$DEXTER/script_tools/functions_library.sh
-
-# Check for a GoPiGo directory.  If it doesn't exist, create it.
 GOPIGO_DIR=$DEXTER_PATH/GoPiGo
-if folder_exists $GOPIGO_DIR; then
-    echo "GoPiGo Directory Exists"
-    cd $DEXTER_PATH/GoPiGo  # Go to directory
-    sudo git fetch origin       # Hard reset the git files
-    sudo git reset --hard
-    sudo git merge origin/master
-else
-    cd $DEXTER_PATH
-    git clone https://github.com/DexterInd/GoPiGo
-    cd $DEXTER_PATH/GoPiGo
-fi
-change_branch  $BRANCH # change to a branch we're working on.
-
-pushd $DEXTER_PATH/GoPiGo/Setup > /dev/null
-feedback "--> UPDATING LIBRARIES"
-feedback "------------------"
-bash ./install.sh
-popd > /dev/null
-
-#####################################################
-
-# This script updates the the code repos on Raspbian for Robots.
-
-# definitions needed for standalone call
-PIHOME=/home/pi
-DEXTER=Dexter
-DEXTER_PATH=$PIHOME/$DEXTER
-RASPBIAN=$PIHOME/di_update/Raspbian_For_Robots
-GROVEPI_DIR=$DEXTER_PATH/GrovePi
 DEXTERSCRIPT=$DEXTER_PATH/lib/Dexter/script_tools
 
 # whether to install the dependencies or not (avrdude, apt-get, wiringpi, and so on)
@@ -85,7 +52,7 @@ for i; do
   esac
 done
 
-# show some feedback for the GrovePi
+# show some feedback for the GoPiGo
 echo "  _____            _                                ";
 echo " |  __ \          | |                               ";
 echo " | |  | | _____  _| |_ ___ _ __                     ";
@@ -107,11 +74,11 @@ echo " "
 # show some feedback on the console
 if [ -f $DEXTERSCRIPT/functions_library.sh ]; then
   source $DEXTERSCRIPT/functions_library.sh
-  feedback "Welcome to GrovePi Installer."
+  feedback "Welcome to GoPiGo Installer."
 else
-  echo "Welcome to GrovePi Installer."
+  echo "Welcome to GoPiGo Installer."
 fi
-echo "Updating GrovePi for $selectedbranch branch with the following options:"
+echo "Updating GoPiGo for $selectedbranch branch with the following options:"
 ([[ $installdependencies = "true" ]] && echo "  --no-dependencies=false") || echo "  --no-dependencies=true"
 ([[ $updaterepo = "true" ]] && echo "  --no-update-aptget=false") || echo "  --no-update-aptget=true"
 ([[ $install_pkg_scriptools = "true" ]] && echo "  --bypass-pkg-scriptools=false") || echo "  --bypass-pkg-scriptools=true"
@@ -157,20 +124,20 @@ cd $DEXTER_PATH
 
 # it's simpler and more reliable (for now) to just delete the repo and clone a new one
 # otherwise, we'd have to deal with all the intricacies of git
-sudo rm -rf $GROVEPI_DIR
+sudo rm -rf $GOPIGO_DIR
 git clone --quiet --depth=1 -b $selectedbranch https://github.com/DexterInd/GrovePi.git
-cd $GROVEPI_DIR
+cd $GOPIGO_DIR
 
 echo "Installing GrovePi dependencies and package. This might take a while.."
 
 # installing dependencies
-pushd $GROVEPI_DIR/Script > /dev/null
+pushd $GOPIGO_DIR/Script > /dev/null
 sudo chmod +x install.sh
 [[ $installdependencies = "true" ]] && sudo bash ./install.sh
 popd > /dev/null
 
 # installing the package itself
-pushd $GROVEPI_DIR/Software/Python > /dev/null
+pushd $GOPIGO_DIR/Software/Python > /dev/null
 [[ $systemwide = "true" ]] && sudo python setup.py install --force \
             && [[ $usepython3exec = "true" ]] && sudo python3 setup.py install --force
 [[ $userlocal = "true" ]] && python setup.py install --force --user \

--- a/Setup/update_gopigo.sh
+++ b/Setup/update_gopigo.sh
@@ -137,7 +137,12 @@ fi
 source $DEXTERSCRIPT/functions_library.sh
 
 # create folders recursively if they don't exist already
-mkdir -p $DEXTER_PATH
+# we use sudo for creating the dir(s) because on older versions of R4R
+# the sudo command is used, and hence we need to be sure we have write permissions.
+sudo mkdir -p $DEXTER_PATH
+# still only available for the pi user
+# shortly after this, we'll make it work for any user
+sudo chown pi:pi -R $DEXTER_PATH
 cd $DEXTER_PATH
 
 # it's simpler and more reliable (for now) to just delete the repo and clone a new one

--- a/Setup/update_gopigo.sh
+++ b/Setup/update_gopigo.sh
@@ -118,11 +118,11 @@ echo "Options used for script_tools script: \"${optionslist[@]}\""
 ################################################
 
 # update script_tools first
-curl --silent -kL dexterindustries.com/update_tools > $PIHOME/tmp_script_tools.sh
+curl --silent -kL dexterindustries.com/update_tools > $PIHOME/.tmp_script_tools.sh
 echo "Installing script_tools. This might take a while.."
-bash $PIHOME/tmp_script_tools.sh ${optionslist[@]} > /dev/null
+bash $PIHOME/.tmp_script_tools.sh ${optionslist[@]} > /dev/null
 ret_val=$?
-rm $PIHOME/tmp_script_tools.sh
+rm $PIHOME/.tmp_script_tools.sh
 if [[ $ret_val -ne 0 ]]; then
   echo "script_tools failed installing with exit code $ret_val. Aborting."
   exit 6

--- a/Software/Python/other_scripts/gopigo_status.py
+++ b/Software/Python/other_scripts/gopigo_status.py
@@ -3,10 +3,12 @@ from gopigo import *
 
 print "---------------------------\n|",
 ver=fw_ver()
+
 if ver==-1:
 	print "| GoPiGo Not Found"
 	print "---------------------------"
 	exit()
+
 print "GoPiGo Found"
 print "| Firmware version:",ver
 print "| Battery voltage :",volt(),"V"

--- a/Software/Python/requirements.txt
+++ b/Software/Python/requirements.txt
@@ -1,3 +1,5 @@
 future
 smbus-cffi
 tornado
+pyusb
+python-periphery==1.1.0


### PR DESCRIPTION
Again, this one has been tested thoroughly on mine machine it worked fine. There are a couple of more tests I want to run and @mattallen37 you can give it a spin and see how it handles.

It's backwards compatible and it runs fine on a fresh image of Lite Stretch.

Added to this PR you can also see the documentation on how to install the robot. This documentation can be found in `Setup/README.md`.

*There are still some things to consider about the old R4R (key: permissions). This is to be ignored by anyone except me.* 

------------

## Installing

You need internet access for the following step(s).

The quickest way for installing the GoPiGo is to enter the following command:
```
curl -kL dexterindustries.com/update_gopigo | bash
```

By default, the GoPiGo package is installed system-wide and [script_tools](https://github.com/DexterInd/script_tools) is completely updated each time the script is ran.

An example using options appended to the command can be:
```
curl -kL dexterindustries.com/update_gopigo | bash -s  -- --user-local --no-update-aptget --no-dependencies
```

## Command Options

The options that can be appended to this command are:

* `--no-dependencies` - skip installing any dependencies for the GoPiGo. It's supposed to be used on each consecutive update after the initial install has gone through.
* `--no-update-aptget` - to skip using `sudo apt-get update` before installing dependencies. For this to be useful, `--no-dependencies` has to be not used.
* `--bypass-pkg-scriptools` - skips installing/updating the python package for  [script_tools](https://github.com/DexterInd/script_tools).
* `--user-local` - install the python package for the GoPiGo in the home directory of the user. This doesn't require any special read/write permissions: the actual command used is (`python setup.py install --force --user`).
* `--env-local` - install the python package for the GoPiGo within the given environment without elevated privileges: the actual command used is (`python setup.py install --force`).
* `--system-wide` - install the python package for the GoPiGo within the sytem-wide environment with `sudo`: the actual command used is (`sudo python setup.py install --force`).

Important to remember is that `--user-local`, `--env-local` and `--system-wide` options are all mutually-exclusive - they cannot be used together.
As a last thing, different versions of it can be pulled by appending a corresponding branch name or tag.