### PR TITLE
rewrite Control Panel

### DIFF
--- a/Software/Python/control_panel/control_panel_gui.py
+++ b/Software/Python/control_panel/control_panel_gui.py
@@ -14,7 +14,7 @@ except ImportError:
     raise ImportError,"The wxPython module is required to run this program"
 
 import atexit
-atexit.register(gopigo.stop)    
+atexit.register(gopigo.stop)
 
 left_led = 0
 right_led = 0
@@ -108,30 +108,28 @@ class MainPanel(wx.Panel):
         firmwareSizer.Add( self.firmware_label, 0, wx.ALIGN_CENTER|wx.EXPAND )
 
         trimbuttons_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        trim_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        
-        self.trim_label = wx.StaticText(self, -1, label=str(trim_val))
         trim_read_button = wx.Button(self, label="  Trim Read ")
         self.Bind(wx.EVT_BUTTON, self.trim_read_button_OnButtonClick, trim_read_button)
         trim_test_button = wx.Button(self, label="Trim Test ")
         self.Bind(wx.EVT_BUTTON, self.trim_test_button_OnButtonClick, trim_test_button)
         trim_write_button = wx.Button(self, label="Trim Write")
         self.Bind(wx.EVT_BUTTON, self.trim_write_button_OnButtonClick, trim_write_button)
+
+        # trimbuttons_sizer.AddSpacer(30)
+        trimbuttons_sizer.Add( trim_read_button, 0, wx.ALIGN_CENTER )
+        trimbuttons_sizer.AddSpacer(30)
+        trimbuttons_sizer.Add( trim_test_button, 0,  wx.ALIGN_CENTER)
+        trimbuttons_sizer.AddSpacer(30)
+        trimbuttons_sizer.Add( trim_write_button, 0,  wx.ALIGN_CENTER )
+
+        trim_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        self.trim_label = wx.StaticText(self, -1, label="Trim: "+str(trim_val))
         self.slider = wx.Slider(self, value=0, minValue=-100, maxValue=100, size=(250, -1), style=wx.SL_HORIZONTAL)
         self.slider.Bind(wx.EVT_SCROLL, self.OnSliderScroll)
 
-
-        trimbuttons_sizer.AddSpacer(30)
-        trimbuttons_sizer.Add( trim_read_button, 0, wx.EXPAND )
-        trimbuttons_sizer.AddSpacer(30)
-        trimbuttons_sizer.Add( trim_test_button, 0, wx.EXPAND )
-        trimbuttons_sizer.AddSpacer(30)
-        trimbuttons_sizer.Add( trim_write_button, 0, wx.EXPAND )
+        trim_sizer.Add( self.trim_label, 0, wx.ALIGN_CENTER )
         trim_sizer.AddSpacer(30)
-        trim_sizer.Add( self.trim_label, 0 )
-        trim_sizer.AddSpacer(30)
-        trim_sizer.Add( self.slider, 0, wx.EXPAND )
-
+        trim_sizer.Add( self.slider, 0, wx.ALIGN_CENTER )
 
         # Exit
         exit_sizer = wx.BoxSizer(wx.HORIZONTAL)
@@ -149,11 +147,12 @@ class MainPanel(wx.Panel):
         main_sizer.AddSpacer(10)
         main_sizer.Add(bwdSizer, 0,  wx.ALIGN_CENTER)
         main_sizer.AddSpacer(40)
+        main_sizer.Add(trimbuttons_sizer, 0, wx.ALIGN_CENTER)
+        main_sizer.AddSpacer(5)
+        main_sizer.Add(trim_sizer, 0, wx.ALIGN_CENTER)
+        main_sizer.AddSpacer(30)
         main_sizer.Add(batterySizer, 0)
         main_sizer.Add(firmwareSizer, 0)
-        main_sizer.AddSpacer(30)
-        main_sizer.Add(trimbuttons_sizer, 0)
-        main_sizer.Add(trim_sizer, 0)
         main_sizer.AddSpacer(20)
         main_sizer.Add(exit_sizer, 0, wx.ALIGN_RIGHT)
         
@@ -210,7 +209,7 @@ class MainPanel(wx.Panel):
         else:
             trim_val = trim_val-100
         self.slider.SetValue(trim_val)
-        self.trim_label.SetLabel(str(trim_val))
+        self.trim_label.SetLabel("Trim: "+str(trim_val))
         
     def trim_test_button_OnButtonClick(self,event):
         global slider_val
@@ -224,7 +223,7 @@ class MainPanel(wx.Panel):
         global slider_val
         obj = event.GetEventObject()
         slider_val = obj.GetValue()
-        self.trim_label.SetLabel(str(slider_val))
+        self.trim_label.SetLabel("Trim: "+str(slider_val))
         
     def onClose(self, event):	# Close the entire program.
         self.frame.Close()
@@ -232,7 +231,7 @@ class MainPanel(wx.Panel):
 class MainFrame(wx.Frame):
     def __init__(self):
         wx.Log.SetVerbose(False)
-        wx.Frame.__init__(self, None, title='GoPiGo Control Panel', size=(475,510))
+        wx.Frame.__init__(self, None, title='GoPiGo Control Panel', size=(475,550))
         panel = MainPanel(self)
         self.Center()
 

--- a/Software/Python/control_panel/control_panel_gui.py
+++ b/Software/Python/control_panel/control_panel_gui.py
@@ -16,139 +16,148 @@ except ImportError:
 import atexit
 atexit.register(gopigo.stop)    
 
-left_led=0
-right_led=0
-trim_val=gopigo.trim_read()
-v=gopigo.volt()
-f=gopigo.fw_ver()
-slider_val=gopigo.trim_read()
+left_led = 0
+right_led = 0
+trim_val = gopigo.trim_read()
+if trim_val == -3:
+    trim_val = 0
+v = gopigo.volt()
+f = gopigo.fw_ver()
+slider_val = trim_val
 
-class gopigo_control_app(wx.Frame):
+class MainPanel(wx.Panel):
     slider=0
-    def __init__(self,parent,id,title):
-        wx.Frame.__init__(self,parent,id,title,size=(475,600))
-        self.parent = parent
-        self.initialize()
-        # Exit
-        exit_button = wx.Button(self, label="Exit", pos=(240+75,550))
-        exit_button.Bind(wx.EVT_BUTTON, self.onClose)
-        
-        # robot = "/home/pi/Desktop/GoBox/Troubleshooting_GUI/dex.png"
-        # png = wx.Image(robot, wx.BITMAP_TYPE_ANY).ConvertToBitmap()
-        # wx.StaticBitmap(self, -1, png, (0, 0), (png.GetWidth()-320, png.GetHeight()-20))
-        # self.Bind(wx.EVT_ERASE_BACKGROUND, self.OnEraseBackground)		# Sets background picture
-    
-    #----------------------------------------------------------------------
-    def OnEraseBackground(self, evt):
-        """
-        Add a picture to the background
-        """
-        # yanked from ColourDB.py
-        dc = evt.GetDC()
- 
-        if not dc:
-            dc = wx.ClientDC(self)
-            rect = self.GetUpdateRegion().GetBox()
-            dc.SetClippingRect(rect)
-        dc.Clear()	
-        # bmp = wx.Bitmap("/home/pi/Desktop/GoBox/Troubleshooting_GUI/dex.png")	# Draw the photograph.
-        # dc.DrawBitmap(bmp, 0, 400)						# Absolute position of where to put the picture
+    def __init__(self, parent):
+        wx.Panel.__init__(self, parent=parent)
+        self.SetBackgroundStyle(wx.BG_STYLE_CUSTOM)
+        self.SetBackgroundColour(wx.WHITE)
+        self.frame = parent
 
-
-    def initialize(self):
-        sizer = wx.GridBagSizer()
-
-        x=75
-        y=175 
-        dist=60
+        # main sizer
+        main_sizer = wx.BoxSizer(wx.VERTICAL)
+        main_sizer.AddSpacer(10)
 
         # if we can auto-detect, then give feedback to the user
         if no_auto_detect == False:
             detected_robot = auto_detect_robot.autodetect()
             if detected_robot != "GoPiGo":
                 detected_robot_str = wx.StaticText(self,-1,
-                    label="Warning: Could not find a GoPiGo",pos=(x-30+dist*2,4))
+                    label="Warning: Could not find a GoPiGo")
                 detected_robot_str.SetForegroundColour('red')
-                sizer.AddStretchSpacer((1,1))
-                sizer.Add(detected_robot_str,(0,1))
-                sizer.AddStretchSpacer((1,1))
+                warning_sizer = wx.BoxSizer(wx.HORIZONTAL)
+                warning_sizer.Add(detected_robot_str, 0, wx.EXPAND| wx.ALIGN_CENTER)
+                main_sizer.Add(warning_sizer, 0, wx.ALIGN_CENTER)
 
-        # Motion buttons
-        left_button = wx.Button(self,-1,label="Left", pos=(x,y))
-        sizer.Add(left_button, (0,1))
-        self.Bind(wx.EVT_BUTTON, self.left_button_OnButtonClick, left_button)
+        # LED buttons
+        led_sizer = wx.BoxSizer(wx.HORIZONTAL)
 
-        stop_button = wx.Button(self,-1,label="Stop", pos=(x+dist*2,y))
-        stop_button.SetBackgroundColour('red')
-        sizer.Add(stop_button, (0,1))
-        self.Bind(wx.EVT_BUTTON, self.stop_button_OnButtonClick, stop_button)
-
-        right_button = wx.Button(self,-1,label="Right", pos=(x+dist*4,y))
-        sizer.Add(right_button, (0,1))
-        self.Bind(wx.EVT_BUTTON, self.right_button_OnButtonClick, right_button)
-        
-        fwd_button = wx.Button(self,-1,label="Forward", pos=(x+dist*2,y-dist))
-        sizer.Add(fwd_button, (0,1))
-        self.Bind(wx.EVT_BUTTON, self.fwd_button_OnButtonClick, fwd_button)
-        
-        bwd_button = wx.Button(self,-1,label="Back", pos=(x+dist*2,y+dist))
-        sizer.Add(bwd_button, (0,1))
-        self.Bind(wx.EVT_BUTTON, self.bwd_button_OnButtonClick, bwd_button)
-        
-        # Led buttons
-        x=75
-        y=25
-        left_led_button = wx.Button(self,-1,label="Left LED", pos=(x,y))
-        sizer.Add(left_led_button, (0,1))
+        left_led_button = wx.Button(self, label="Left LED")
         self.Bind(wx.EVT_BUTTON, self.left_led_button_OnButtonClick, left_led_button)
 
-        right_led_button = wx.Button(self,-1,label="Right LED", pos=(x+dist*4,y))
-        sizer.Add(right_led_button, (0,1))
+        right_led_button = wx.Button(self, label="Right LED")
         self.Bind(wx.EVT_BUTTON, self.right_led_button_OnButtonClick, right_led_button)       
+
+        led_sizer.AddSpacer(30)
+        led_sizer.Add(left_led_button, 0, wx.ALIGN_CENTER)
+        led_sizer.AddSpacer(80)
+        led_sizer.Add(right_led_button, 0, wx.ALIGN_CENTER)
+        led_sizer.AddSpacer(30)
+
+
+        fwd_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        fwd_button = wx.Button(self, label="Forward")
+        self.Bind(wx.EVT_BUTTON, self.fwd_button_OnButtonClick, fwd_button)
+        fwd_sizer.Add(fwd_button, 0, wx.ALIGN_CENTER)
+
+        middle_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        left_button = wx.Button(self, label="Left")
+        self.Bind(wx.EVT_BUTTON, self.left_button_OnButtonClick, left_button)
+        stop_button = wx.Button(self, label="Stop")
+        stop_button.SetBackgroundColour('red')
+        self.Bind(wx.EVT_BUTTON, self.stop_button_OnButtonClick, stop_button)
+        right_button = wx.Button(self, label="Right")
+        self.Bind(wx.EVT_BUTTON, self.right_button_OnButtonClick, right_button)
+
+        middle_sizer.Add(left_button, 0, wx.ALIGN_CENTER)
+        middle_sizer.AddSpacer(20)
+        middle_sizer.Add(stop_button,  0, wx.ALIGN_CENTER)
+        middle_sizer.AddSpacer(20)
+        middle_sizer.Add(right_button,  0, wx.ALIGN_CENTER)
         
-        y=320
-        battery_button = wx.Button(self,-1,label="Check Battery Voltage\t ", pos=(x,y))
-        sizer.Add(battery_button, (0,1))
+        bwdSizer = wx.BoxSizer(wx.HORIZONTAL)
+        bwd_button = wx.Button(self, label="Back")
+        self.Bind(wx.EVT_BUTTON, self.bwd_button_OnButtonClick, bwd_button)
+        bwdSizer.Add(bwd_button,  0, wx.ALIGN_CENTER)
+
+        batterySizer = wx.BoxSizer(wx.HORIZONTAL)
+        battery_button = wx.Button(self, label="Check Battery Voltage")
         self.Bind(wx.EVT_BUTTON, self.battery_button_OnButtonClick, battery_button)
+        self.battery_label = wx.StaticText(self, label=str(round(v,1))+"V")
+        batterySizer.AddSpacer(30)
+        batterySizer.Add(battery_button, 0, wx.ALIGN_LEFT )
+        batterySizer.AddSpacer(20)
+        batterySizer.Add( self.battery_label,0, wx.ALIGN_CENTER|wx.EXPAND )
 
-        firmware_button = wx.Button(self,-1,label="Check Firmware Version\t", pos=(x,y+dist/2))
-        sizer.Add(firmware_button, (0,1))
+        firmwareSizer = wx.BoxSizer(wx.HORIZONTAL)
+        firmware_button = wx.Button(self,-1,label="Check Firmware Version")
         self.Bind(wx.EVT_BUTTON, self.firmware_button_OnButtonClick, firmware_button)        
-        # Set up labels
-        # self.label = wx.StaticText(self,-1,label=u'  ',pos=(25,y+150))       
-        # self.label_top = wx.StaticText(self,-1,label=u'Test',pos=(25,0))
-        # sizer.Add( self.label, (1,0),(1,2), wx.EXPAND )
-        # sizer.Add( self.label_top, (1,0),(1,2), wx.EXPAND )
-        
-        self.battery_label = wx.StaticText(self,-1,label=str(v)+"V",pos=(x+dist*2+45,y+6))
-        sizer.Add( self.battery_label, (1,0),(1,2), wx.EXPAND )
-        
-        self.firmware_label = wx.StaticText(self,-1,label=str(f),pos=(x+dist*2+45,y+6+dist/2))
-        sizer.Add( self.firmware_label, (1,0),(1,2), wx.EXPAND )
-        
-        self.trim_label = wx.StaticText(self,-1,label="You can adjust the trim of your GoPiGo to help it go straight forward.\nUse the slider below to adjust the trim difference between the left\nand right motors.",pos=(x,y+6+dist/2+40))
-        sizer.Add( self.firmware_label, (1,0),(1,2), wx.EXPAND )
-        
-        y=460
-        self.trim_label = wx.StaticText(self,-1,label=str(trim_val),pos=(x+dist*2,y+6))
-        sizer.Add( self.trim_label, (1,0),(1,2), wx.EXPAND )
-        
-        trim_read_button = wx.Button(self,-1,label="  Trim Read ", pos=(x,y))
-        sizer.Add(trim_read_button, (0,1))
-        self.Bind(wx.EVT_BUTTON, self.trim_read_button_OnButtonClick, trim_read_button)
+        self.firmware_label = wx.StaticText(self,-1,label=str(f))
+        firmwareSizer.AddSpacer(30)
+        firmwareSizer.Add(firmware_button, 0, wx.ALIGN_LEFT)
+        firmwareSizer.AddSpacer(15)
+        firmwareSizer.Add( self.firmware_label, 0, wx.ALIGN_CENTER|wx.EXPAND )
 
-        trim_test_button = wx.Button(self,-1,label="Trim Test ", pos=(x,y+dist/2))
-        sizer.Add(trim_test_button, (0,1))
+        trimbuttons_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        trim_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        
+        self.trim_label = wx.StaticText(self, -1, label=str(trim_val))
+        trim_read_button = wx.Button(self, label="  Trim Read ")
+        self.Bind(wx.EVT_BUTTON, self.trim_read_button_OnButtonClick, trim_read_button)
+        trim_test_button = wx.Button(self, label="Trim Test ")
         self.Bind(wx.EVT_BUTTON, self.trim_test_button_OnButtonClick, trim_test_button)
-        
-        trim_write_button = wx.Button(self,-1,label="Trim Write", pos=(x,y+dist))
-        sizer.Add(trim_write_button, (0,1))
+        trim_write_button = wx.Button(self, label="Trim Write")
         self.Bind(wx.EVT_BUTTON, self.trim_write_button_OnButtonClick, trim_write_button)
-        
-        self.slider = wx.Slider(self, value=0, minValue=-100, maxValue=100, pos=(x+dist*2, y+dist/2),size=(250, -1), style=wx.SL_HORIZONTAL)
+        self.slider = wx.Slider(self, value=0, minValue=-100, maxValue=100, size=(250, -1), style=wx.SL_HORIZONTAL)
         self.slider.Bind(wx.EVT_SCROLL, self.OnSliderScroll)
+
+
+        trimbuttons_sizer.AddSpacer(30)
+        trimbuttons_sizer.Add( trim_read_button, 0, wx.EXPAND )
+        trimbuttons_sizer.AddSpacer(30)
+        trimbuttons_sizer.Add( trim_test_button, 0, wx.EXPAND )
+        trimbuttons_sizer.AddSpacer(30)
+        trimbuttons_sizer.Add( trim_write_button, 0, wx.EXPAND )
+        trim_sizer.AddSpacer(30)
+        trim_sizer.Add( self.trim_label, 0 )
+        trim_sizer.AddSpacer(30)
+        trim_sizer.Add( self.slider, 0, wx.EXPAND )
+
+
+        # Exit
+        exit_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        exit_button = wx.Button(self, label="Exit")
+        exit_button.Bind(wx.EVT_BUTTON, self.onClose)
+        exit_sizer.Add(exit_button,0, wx.ALIGN_RIGHT)
+        exit_sizer.AddSpacer(30)
+
+
+        main_sizer.Add(led_sizer, 0,  wx.ALIGN_CENTER)
+        main_sizer.AddSpacer(10)
+        main_sizer.Add(fwd_sizer, 0,  wx.ALIGN_CENTER)
+        main_sizer.AddSpacer(10)
+        main_sizer.Add(middle_sizer, 0,  wx.ALIGN_CENTER)
+        main_sizer.AddSpacer(10)
+        main_sizer.Add(bwdSizer, 0,  wx.ALIGN_CENTER)
+        main_sizer.AddSpacer(40)
+        main_sizer.Add(batterySizer, 0)
+        main_sizer.Add(firmwareSizer, 0)
+        main_sizer.AddSpacer(30)
+        main_sizer.Add(trimbuttons_sizer, 0)
+        main_sizer.Add(trim_sizer, 0)
+        main_sizer.AddSpacer(20)
+        main_sizer.Add(exit_sizer, 0, wx.ALIGN_RIGHT)
         
-        self.Show(True)     
+        self.SetSizerAndFit(main_sizer)
 
     def battery_button_OnButtonClick(self,event):
         global v
@@ -194,11 +203,12 @@ class gopigo_control_app(wx.Frame):
             right_led=0
             
     def trim_read_button_OnButtonClick(self,event):
+        global trim_val
         trim_val=gopigo.trim_read()
-        if trim_val==-3:
-            trim==0
+        if trim_val == -3:
+            trim_val = 0
         else:
-            trim_val=trim_val-100
+            trim_val = trim_val-100
         self.slider.SetValue(trim_val)
         self.trim_label.SetLabel(str(trim_val))
         
@@ -210,16 +220,29 @@ class gopigo_control_app(wx.Frame):
         global slider_val
         gopigo.trim_write(slider_val)
             
-    def OnSliderScroll(self,event):
+    def OnSliderScroll(self, event):
         global slider_val
         obj = event.GetEventObject()
         slider_val = obj.GetValue()
         self.trim_label.SetLabel(str(slider_val))
         
     def onClose(self, event):	# Close the entire program.
-        self.Close()
+        self.frame.Close()
+
+class MainFrame(wx.Frame):
+    def __init__(self):
+        wx.Log.SetVerbose(False)
+        wx.Frame.__init__(self, None, title='GoPiGo Control Panel', size=(475,510))
+        panel = MainPanel(self)
+        self.Center()
+
+class Main(wx.App):
+    def __init__(self, redirect=False, filename=None):
+        """Constructor"""
+        wx.App.__init__(self, redirect, filename)
+        dlg = MainFrame()
+        dlg.Show()
 
 if __name__ == "__main__":
-    app = wx.App()
-    frame = gopigo_control_app(None,-1,'GoPiGo Control Panel')
+    app = Main()
     app.MainLoop()

--- a/Software/Python/control_panel/gopigo_control_panel.desktop
+++ b/Software/Python/control_panel/gopigo_control_panel.desktop
@@ -5,5 +5,5 @@ Name=GoPiGo Control Panel
 Comment=GoPiGo Control Panel
 #Icon=/usr/share/icons/gnome/scalable/devices/input-gaming-symbolic.svg
 Icon=/home/pi/Dexter/GoPiGo/Software/Python/control_panel/GoPiGo.png
-Exec=lxterminal  --title "GoPiGo Control Panel - Do not close this window!" --command "gksu python /home/pi/Dexter/GoPiGo/Software/Python/control_panel/control_panel_gui.py"
+Exec=python /home/pi/Dexter/GoPiGo/Software/Python/control_panel/control_panel_gui.py
 NoDisplay=true


### PR DESCRIPTION
Moving Control Panel to wxpython3.
Desktop icon no longer launches a terminal, but directly to Python.

Note: I haven't changed the calls to trimming but I don't think they work. Like, I don't think they worked to start with.