### PR TITLE
hotfix - use SW I2C instead of the Raspberry Pi's HW I2C

### DIFF
--- a/Software/Python/gopigo.py
+++ b/Software/Python/gopigo.py
@@ -124,7 +124,7 @@ debug=0
 #Write I2C block
 def write_i2c_block(command, block):
 	try:
-		op = i2c.write_reg_list(command, block)
+		op = i2c.write_reg_list(command[0], block)
 		time.sleep(.005)
 		return op
 	except IOError:


### PR DESCRIPTION
I have changed the bus on which the GoPiGo communicates with the Raspberry Pi. It's now set to use `RPI_1SW`. 

This has also been tested and works as expected. 